### PR TITLE
Single resource can also contain top level links

### DIFF
--- a/lib/resource-serializer.js
+++ b/lib/resource-serializer.js
@@ -1,8 +1,21 @@
 'use strict';
+var _ = require('lodash');
 var SerializerUtils = require('./serializer-utils');
 
 function ResourceSerializer(collectionName, record, opts) {
   var payload = { data: {} };
+
+  function getLinks(links) {
+    return _.mapValues(links, function (value) {
+      if (_.isFunction(value)) {
+        return value(record);
+      } else {
+        return value;
+      }
+    });
+  }
+
+  if (opts.topLevelLinks) { payload.links = getLinks(opts.topLevelLinks); }
 
   var serializerUtils = new SerializerUtils(collectionName, record, payload,
     opts);

--- a/test/serializer.js
+++ b/test/serializer.js
@@ -743,6 +743,29 @@ describe('JSON API Serializer', function () {
     });
   });
 
+  describe('Top level links (Resource)', function () {
+    it('should be set', function (done) {
+      var dataSet = {
+        id: '54735750e16638ba1eee59cb',
+        firstName: 'Sandro',
+        lastName: 'Munda',
+      };
+
+      var json = new JsonApiSerializer('users', dataSet, {
+        topLevelLinks: {
+          self: 'http://localhost:3000/api/users/54735750e16638ba1eee59cb'
+        },
+        attributes: ['firstName', 'lastName'],
+      });
+
+      expect(json).to.have.property('links').eql({
+        self: 'http://localhost:3000/api/users/54735750e16638ba1eee59cb'
+      });
+
+      done(null, json);
+    });
+  });
+
   describe('Top level links (Function)', function () {
     it('should be set', function (done) {
       var dataSet = [{


### PR DESCRIPTION
When setting top level links for a single resource, the links are currently omitted. According to the spec, top level links are related to the primary data which could also be a single resource.