### PR TITLE
fix to prevent primitive array items from being sent to keyForAttribute (fixes #29)

### DIFF
--- a/lib/serializer-utils.js
+++ b/lib/serializer-utils.js
@@ -19,7 +19,11 @@ module.exports = function (collectionName, record, payload, opts) {
       });
     } else if (_.isArray(attribute)) {
       return attribute.map(function (attr) {
-        return keyForAttribute(attr);
+        if (isComplexType(attr)) {
+          return keyForAttribute(attr);
+        } else {
+          return attr;
+        }
       });
     } else {
       if (_.isFunction(opts.keyForAttribute)) {

--- a/test/serializer.js
+++ b/test/serializer.js
@@ -2,6 +2,7 @@
 /* global describe, it */
 
 var expect = require('chai').expect;
+var _ = require('lodash');
 
 var JsonApiSerializer = require('../lib/serializer');
 
@@ -163,6 +164,30 @@ describe('Options', function () {
           books: [{ 'created_at': '2015-08-04T06:09:24.864Z' }],
           address: { 'zip_code': 42912 }
         });
+
+      done(null, json);
+    });
+
+    it('should ignore primitive array items', function (done) {
+      var dataSet = {
+        id: '1',
+        firstName: 'Sandro',
+        lastName: 'Munda',
+        phoneNumber: ['555-555-5555'],
+        address: { zipCode: 42912 }
+      };
+
+      var json = new JsonApiSerializer('user', dataSet, {
+        attributes: ['firstName', 'lastName', 'books', 'address', 'phoneNumber'],
+        address: { attributes: ['zipCode'] },
+        pluralizeType: false,
+        keyForAttribute: function (attribute) {
+          return _.camelCase(attribute);
+        }
+      });
+
+      expect(json.data.type).equal('user');
+      expect(json.data.attributes).to.have.property('phoneNumber').that.is.eql(['555-555-5555']);
 
       done(null, json);
     });


### PR DESCRIPTION
This PR prevents primitive array items from being passed as keys to the `keyForAttribute` function. This can cause issues, especially if you're using a custom `keyForAttribute` function.

See #29 for more information.