### PR TITLE
Add attributeCase option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,8 @@ API](http://jsonapi.org) (1.0 compliant).
         - *topLevelLinks*: An object that describes the top-level links. Values can be *string* or a *function* (see examples below)
         - *dataLinks*: An object that describes the links inside data. Values can be *string* or a *function* (see examples below)
         - *relationshipLinks*: An object that describes the links inside relationships. Values can be *string* or a *function* (see examples below)
-        - *keyForAttribute*: A function that maps the attribute (passed as an argument) to the key.
-        - *pluralizeType*: A boolean to indicate if the type must be pluralized or not. Default: true.
-        - *typeForAttribute*: A function that maps the attribute (passed as an argument) to the type you want to override. Option *pluralizeType* ignored if set.
-        - *meta*: An object to include non-standard meta-information.
-        - *attributeCase*: Changes the attribute case. Defaults to 'dash-case'
-            - dash-case
+         - *keyForAttribute*: A function or string to customize attributes. Functions are passed the attribute as a single argument and expect a string to be returned. Strings are aliases for inbuilt functions for common case conversions. Options include: 
+            - dash-case (default)
             - lisp-case
             - spinal-case
             - kebab-case
@@ -34,6 +30,9 @@ API](http://jsonapi.org) (1.0 compliant).
             - snake_case
             - CamelCase
             - camelCase
+        - *pluralizeType*: A boolean to indicate if the type must be pluralized or not. Default: true.
+        - *typeForAttribute*: A function that maps the attribute (passed as an argument) to the type you want to override. Option *pluralizeType* ignored if set.
+        - *meta*: An object to include non-standard meta-information.        
 
 
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,20 @@ API](http://jsonapi.org) (1.0 compliant).
         - *topLevelLinks*: An object that describes the top-level links. Values can be *string* or a *function* (see examples below)
         - *dataLinks*: An object that describes the links inside data. Values can be *string* or a *function* (see examples below)
         - *relationshipLinks*: An object that describes the links inside relationships. Values can be *string* or a *function* (see examples below)
-        - *keyForAttribute*: A function that maps the attribute (passed as an argument) to the key. Attributes are dasherized by default.
+        - *keyForAttribute*: A function that maps the attribute (passed as an argument) to the key.
         - *pluralizeType*: A boolean to indicate if the type must be pluralized or not. Default: true.
         - *typeForAttribute*: A function that maps the attribute (passed as an argument) to the type you want to override. Option *pluralizeType* ignored if set.
         - *meta*: An object to include non-standard meta-information.
+        - *attributeCase*: Changes the attribute case. Defaults to 'dash-case'
+            - dash-case
+            - lisp-case
+            - spinal-case
+            - kebab-case
+            - underscore_case
+            - snake_case
+            - CamelCase
+            - camelCase
+
 
 
 ## Examples

--- a/lib/serializer-utils.js
+++ b/lib/serializer-utils.js
@@ -4,8 +4,21 @@ var inflection = require('inflection');
 
 module.exports = function (collectionName, record, payload, opts) {
 
-  function dasherize(attribute) {
-    return inflection.dasherize(inflection.underscore(attribute));
+  function caserize(attribute){
+    var attributeCase = opts.attributeCase || 'dash-case';
+
+    var caseMapping = {
+      'dash-case': inflection.dasherize,
+      'lisp-case': inflection.dasherize,
+      'spinal-case': inflection.dasherize,
+      'kebab-case': inflection.dasherize,
+      'underscore_case': inflection.underscore,
+      'snake_case': inflection.underscore,
+      'CamelCase': inflection.camelize,
+      'camelCase': _.partialRight( inflection.camelize, true)
+    };
+
+    return caseMapping[ attributeCase ]( inflection.underscore( attribute ) );
   }
 
   function keyForAttribute(attribute) {
@@ -29,7 +42,7 @@ module.exports = function (collectionName, record, payload, opts) {
       if (_.isFunction(opts.keyForAttribute)) {
         return opts.keyForAttribute(attribute);
       } else {
-        return dasherize(attribute);
+        return caserize(attribute);
       }
     }
   }

--- a/test/serializer.js
+++ b/test/serializer.js
@@ -255,6 +255,95 @@ describe('Options', function () {
       done(null, json);
     });
   });
+
+  describe('attributeCase', function () {
+    it('should update the key case to dash-case', function (done) {
+      var dataSet = {
+        id: '1',
+        firstName: 'Sandro',
+      };
+
+      var jsonDashCase = new JsonApiSerializer('user', dataSet, {
+        attributes: ['firstName'],
+        attributeCase: 'dash-case'
+      });
+
+      var jsonLispCase = new JsonApiSerializer('user', dataSet, {
+        attributes: ['firstName'],
+        attributeCase: 'lisp-case'
+      });
+
+      var jsonSpinalCase = new JsonApiSerializer('user', dataSet, {
+        attributes: ['firstName'],
+        attributeCase: 'spinal-case'
+      });
+      var jsonKababCase = new JsonApiSerializer('user', dataSet, {
+        attributes: ['firstName'],
+        attributeCase: 'kebab-case'
+      });
+
+      expect(jsonDashCase.data.attributes['first-name']).equal('Sandro');
+      expect(jsonLispCase.data.attributes['first-name']).equal('Sandro');
+      expect(jsonSpinalCase.data.attributes['first-name']).equal('Sandro');
+      expect(jsonKababCase.data.attributes['first-name']).equal('Sandro');
+
+      done(null, jsonDashCase);
+    });
+
+    it('should update the key case to underscore_case', function (done) {
+      var dataSet = {
+        id: '1',
+        firstName: 'Sandro',
+      };
+
+      var jsonUnderscoreCase = new JsonApiSerializer('user', dataSet, {
+        attributes: ['firstName'],
+        attributeCase: 'underscore_case'
+      });
+
+      var jsonSnakeCase = new JsonApiSerializer('user', dataSet, {
+        attributes: ['firstName'],
+        attributeCase: 'snake_case'
+      });
+
+      expect(jsonUnderscoreCase.data.attributes.first_name).equal('Sandro');
+      expect(jsonSnakeCase.data.attributes.first_name).equal('Sandro');
+
+      done(null, jsonUnderscoreCase);
+    });
+
+    it('should update the key case to CamelCase', function (done) {
+      var dataSet = {
+        id: '1',
+        firstName: 'Sandro',
+      };
+
+      var jsonCamelCase = new JsonApiSerializer('user', dataSet, {
+        attributes: ['firstName'],
+        attributeCase: 'CamelCase'
+      });
+
+      expect(jsonCamelCase.data.attributes.FirstName).equal('Sandro');
+
+      done(null, jsonCamelCase);
+    });
+
+    it('should update the key case to camelCase', function (done) {
+      var dataSet = {
+        id: '1',
+        firstName: 'Sandro',
+      };
+
+      var jsonCamelCase = new JsonApiSerializer('user', dataSet, {
+        attributes: ['firstName'],
+        attributeCase: 'camelCase'
+      });
+
+      expect(jsonCamelCase.data.attributes.firstName).equal('Sandro');
+
+      done(null, jsonCamelCase);
+    });
+  });
 });
 
 describe('JSON API Serializer', function () {


### PR DESCRIPTION
JSONAPI 1.0 allows for dash-case, underscore_case, CamelCase or camelCase for attribute names. This pull request adds a 'attributeCase' option to choose which naming convention you wish to use.

- dash-case has been kept as default to ensure this isn't a breaking change
- common case aliases have been included (eg lisp-case for dash-case)
- Unit tests and README updated
