### PR TITLE
Null resources will return null instead of a resource object

### DIFF
--- a/lib/serializer-utils.js
+++ b/lib/serializer-utils.js
@@ -163,6 +163,10 @@ module.exports = function (collectionName, record, payload, opts) {
   this.perform = function () {
     var that = this;
 
+    if( _.isNull( record ) ){
+        return null;
+    }
+
     // Top-level data.
     var data = {
       type: getType(collectionName),

--- a/test/serializer.js
+++ b/test/serializer.js
@@ -322,6 +322,21 @@ describe('JSON API Serializer', function () {
     });
   });
 
+
+  describe('Null data resource', function () {
+    it('should be returned as NULL', function (done) {
+      var resource = null;
+
+      var json = new JsonApiSerializer('users', resource, {
+        attributes: ['firstName', 'lastName'],
+      });
+
+      expect(json).to.have.property('data').and.to.equal(null);
+
+      done(null, json);
+    });
+  });
+
   describe('Nested document', function () {
     it('should be set into the `data.attributes`', function (done) {
       var dataSet = [{


### PR DESCRIPTION
The JSON API spec allows the return type of null for single resource, but jsonapi-serializer will always try to map null to a single resource object.  

This pull request increases compatibility with common ORM libraries which return null/empty arrays when resources are not located.

> Primary data MUST be either: a single resource object, a single resource identifier object, or null, for requests that target single resources

Source http://jsonapi.org/format/#document-top-level





