### PR TITLE
Update test to use valid json api payload

### DIFF
--- a/test/serializer.js
+++ b/test/serializer.js
@@ -965,13 +965,15 @@ describe('JSON API Serializer', function () {
 
       var json = new JsonApiSerializer('users', dataSet, {
         topLevelLinks: {
-          self: 'http://localhost:3000/api/users'
+          self: function(data){
+            return 'http://localhost:3000/api/users/' + data.id;
+          }
         },
         attributes: ['firstName', 'lastName']
       });
 
       expect(json).to.have.property('links').eql({
-        self: 'http://localhost:3000/api/users'
+        self: 'http://localhost:3000/api/users/' + dataSet.id
       });
 
       done(null, json);

--- a/test/serializer.js
+++ b/test/serializer.js
@@ -967,7 +967,7 @@ describe('JSON API Serializer', function () {
         topLevelLinks: {
           self: 'http://localhost:3000/api/users'
         },
-        attributes: ['firstName', 'lastName'],
+        attributes: ['firstName', 'lastName']
       });
 
       expect(json).to.have.property('links').eql({


### PR DESCRIPTION
Fixes test `Top level links with a single resource` so that the payload being tested is a valid json-api payload.  Please see issue #38 for full details.