### PR TITLE
Passing record as second argument into typeForAttribute

### DIFF
--- a/lib/serializer-utils.js
+++ b/lib/serializer-utils.js
@@ -208,7 +208,7 @@ module.exports = function (collectionName, record, payload, opts) {
 
     // Top-level data.
     var data = {
-      type: getType(collectionName),
+      type: getType(collectionName, record),
       id: String(record[getId()])
     };
 

--- a/test/serializer.js
+++ b/test/serializer.js
@@ -74,6 +74,25 @@ describe('Options', function () {
       expect(json.data.type).equal('user_foo');
       done(null, json);
     });
+
+    it('should pass the object as a second variable to the func', function (done) {
+      var dataSet = {
+        id: '1',
+        firstName: 'Sandro',
+        lastName: 'Munda',
+        customType: 'user_foo'
+      };
+
+      var json = new JsonApiSerializer('user', dataSet, {
+        attributes: ['firstName', 'lastName'],
+        typeForAttribute: function (attribute, user) {
+          return user.customType;
+        }
+      });
+
+      expect(json.data.type).equal('user_foo');
+      done(null, json);
+    });
   });
 
   describe('typeForAttributeRecord', function () {


### PR DESCRIPTION
The new type can be based on the original type, as well as other properties of the record.

This, among other things, enables support for heterogenous relations.