### PR TITLE
Reverse attribute access for creating the data object.

### DIFF
--- a/lib/serializer-utils.js
+++ b/lib/serializer-utils.js
@@ -217,11 +217,13 @@ module.exports = function (collectionName, record, payload, opts) {
       data.links = getLinks(record, opts.dataLinks);
     }
 
-    _.each(_.keys(record), function (attribute) {
-      if (!isAttrAllowed(opts.attributes, attribute)) { return; }
-      if (!data.attributes) { data.attributes = {}; }
-
-      that.serialize(data, record, attribute, opts[attribute]);
+    _.each(opts.attributes, function (attribute) {
+      if (record[attribute]) {
+        if (!data.attributes) { data.attributes = {}; }
+        that.serialize(data, record, attribute, opts[attribute]);
+      } else {
+        return;
+      }
     });
 
     return data;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "chai": "^2.3.0",
     "grunt": "^0.4.5",
     "grunt-browserify": "^4.0.0",
-    "mocha": "^2.2.5"
+    "mocha": "^2.2.5",
+    "mongoose": "^4.3.4"
   }
 }

--- a/test/serializer.js
+++ b/test/serializer.js
@@ -1608,4 +1608,20 @@ describe('JSON API Serializer', function () {
       done(null, json);
     });
   });
+
+  describe('Database model objects', function () {
+    it('properly pass on requests for attributes', function () {
+      var mongoose = require('mongoose');
+      var userSchema = new mongoose.Schema({ firstName: String, lastName: String });
+      var User = mongoose.model('User', userSchema);
+      var user1 = new User({ firstName: 'Lawrence', lastName: 'Bennett' });
+      
+      var json = new JsonApiSerializer('users', user1, {
+        attributes: ['firstName', 'lastName']
+      });
+
+      expect(json.data.attributes).to.have.property('first-name');
+      expect(json.data.attributes).to.have.property('last-name');
+    });
+  });
 });


### PR DESCRIPTION
Mongoose is used as an example. Creating a document object in mongoose
gives the 'record' object more than just the attributes to serialize. In
fact, the attributes we're looking for are in the `_doc` property of the
document object. I'm sure this pattern is not just specific to mongoose,
although I don't have enough experience with another O(D|R)M module to
say for certain.

The previous attribute access scheme iterated through the object's keys
to see if the key was in the option's attributes array. This
meant that it did not recurse to find the attributes in `_doc` and
didn't allow the passed record to figure out how to handle the calls.
Additionally, for very large objects, I can imagine this becoming slow.
We're taking two sets and looking for intersection using the larger
set first and checking for existance in the smaller set.

But don't believe me, I haven't done any optimizations like this before.

The new attribute access scheme iterates through the smaller set, the
option's attributes array, and asking the record object for that
attribute. This allows the record object to figure out how to handle it
using all of the magic that it's creating module gave it.

There is also a new test that confirms this behavior.

Fixes #52.