### PR TITLE
fix issue with falsy attribute values

### DIFF
--- a/lib/serializer-utils.js
+++ b/lib/serializer-utils.js
@@ -233,7 +233,7 @@ module.exports = function (collectionName, record, payload, opts) {
     }
 
     _.each(opts.attributes, function (attribute) {
-      if (record[attribute]) {
+      if (attribute in record) {
         if (!data.attributes) { data.attributes = {}; }
         that.serialize(data, record, attribute, opts[attribute]);
       } else {

--- a/test/serializer.js
+++ b/test/serializer.js
@@ -1662,4 +1662,30 @@ describe('JSON API Serializer', function () {
       expect(json.data.attributes).to.have.property('last-name');
     });
   });
+
+  describe('falsy attribute values', function() {
+    it('properly attach falsy attributes', function() {
+      var dataSet = {
+        id: '1',
+        count: 0,
+        bool: false,
+        dbNull: null,
+        emptyString: ''
+      };
+
+      var json = new JSONAPISerializer('tester', {
+        attributes: ['count', 'bool', 'dbNull', 'emptyString']
+      }).serialize(dataSet);
+
+      expect(json.data.attributes).to.have.property('count');
+      expect(json.data.attributes.count).to.equal(0);
+      expect(json.data.attributes).to.have.property('bool');
+      expect(json.data.attributes.bool).to.equal(false);
+      expect(json.data.attributes).to.have.property('db-null');
+      expect(json.data.attributes['db-null']).to.equal(null);
+      expect(json.data.attributes).to.have.property('empty-string');
+      expect(json.data.attributes['empty-string']).to.equal('');
+    });
+  });
+
 });


### PR DESCRIPTION
This fixes issue #59. A few notes below:

* The [existing attempted fix](https://github.com/SeyZ/jsonapi-serializer/pull/61/files) is no good since it excludes `null` values which are both valid in JSON and common from data sources, particularly databases
* I would have preferred to use `hasOwnProperty()` as opposed to the `in` operator, but the [special case you handle for database models](https://github.com/SeyZ/jsonapi-serializer/blob/master/test/serializer.js#L1650) will not work unless properties further down the prototype chain are considered.

This is a major breaking issue for us that didn't surface until 2.1.0. It does not exist in 2.0.x. Please let me know if there's anything I can do to speed up merging this PR and updating the npm module version.