### PR TITLE
Provide serialization-specific options

### DIFF
--- a/lib/serializer-utils.js
+++ b/lib/serializer-utils.js
@@ -152,6 +152,9 @@ module.exports = function (collectionName, record, payload, opts) {
     var that = this;
     var id = getRef(current, dest, opts);
     var type = getType(attribute, dest);
+    if (opts.type) {
+      type = getType(opts.type, dest);
+    }
 
     var relationships = [];
     var includedAttrs = [];

--- a/lib/serializer-utils.js
+++ b/lib/serializer-utils.js
@@ -54,10 +54,10 @@ module.exports = function (collectionName, record, payload, opts) {
     return type;
   }
 
-  function getLinks(current, links, dest) {
+  function getLinks(current, links, dest, opts) {
     return _.mapValues(links, function (value) {
       if (_.isFunction(value)) {
-        return value(record, current, dest);
+        return value(record, current, dest, opts);
       } else {
         return value;
       }
@@ -95,7 +95,7 @@ module.exports = function (collectionName, record, payload, opts) {
     }
   }
 
-  this.serialize = function (dest, current, attribute, opts) {
+  this.serialize = function (dest, current, attribute, opts, serializeOpts) {
     var that = this;
 
     if (isComplexType(current[attribute])) {
@@ -106,11 +106,11 @@ module.exports = function (collectionName, record, payload, opts) {
         var data = null;
         if (_.isArray(current[attribute])) {
           data = current[attribute].map(function (item) {
-            return that.serializeRef(item, current, attribute, opts);
+            return that.serializeRef(item, current, attribute, opts, serializeOpts);
           });
         } else if (_.isPlainObject(current[attribute])) {
           data = that.serializeRef(current[attribute], current, attribute,
-            opts);
+            opts, serializeOpts);
         }
 
         dest.relationships[keyForAttribute(attribute)] = {};
@@ -120,7 +120,7 @@ module.exports = function (collectionName, record, payload, opts) {
 
         if (opts.relationshipLinks) {
           dest.relationships[keyForAttribute(attribute)].links =
-            getLinks(current[attribute], opts.relationshipLinks, dest);
+            getLinks(current[attribute], opts.relationshipLinks, dest, serializeOpts);
         }
 
         if (opts.relationshipMeta) {
@@ -148,7 +148,7 @@ module.exports = function (collectionName, record, payload, opts) {
     }
   };
 
-  this.serializeRef = function (dest, current, attribute, opts) {
+  this.serializeRef = function (dest, current, attribute, opts, serializeOpts) {
     var that = this;
     var id = getRef(current, dest, opts);
     var type = getType(attribute, dest);
@@ -177,7 +177,7 @@ module.exports = function (collectionName, record, payload, opts) {
 
     if (_.isUndefined(opts.included) || opts.included) {
       if (opts.includedLinks) {
-        included.links = getLinks(dest, opts.includedLinks);
+        included.links = getLinks(dest, opts.includedLinks, included, serializeOpts);
       }
 
       pushToIncluded(payload, included);
@@ -216,7 +216,7 @@ module.exports = function (collectionName, record, payload, opts) {
     return ret.attributes;
   };
 
-  this.perform = function () {
+  this.perform = function (serializeOpts) {
     var that = this;
 
     if( _.isNull( record ) ){
@@ -231,13 +231,13 @@ module.exports = function (collectionName, record, payload, opts) {
 
     // Data links.
     if (opts.dataLinks) {
-      data.links = getLinks(record, opts.dataLinks);
+      data.links = getLinks(record, opts.dataLinks, data, serializeOpts);
     }
 
     _.each(opts.attributes, function (attribute) {
       if (attribute in record) {
         if (!data.attributes) { data.attributes = {}; }
-        that.serialize(data, record, attribute, opts[attribute]);
+        that.serialize(data, record, attribute, opts[attribute], serializeOpts);
       } else {
         return;
       }

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -31,7 +31,7 @@ module.exports = function (collectionName, records, opts) {
 
     function resource() {
       payload.data = new SerializerUtils(that.collectionName, records, payload,
-        that.opts).perform(records);
+        that.opts).perform(opts);
 
       return payload;
     }

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -3,7 +3,7 @@ var _ = require('lodash');
 var SerializerUtils = require('./serializer-utils');
 
 module.exports = function (collectionName, records, opts) {
-  this.serialize = function (records) {
+  this.serialize = function (records, opts) {
     var that = this;
     var payload = {};
 
@@ -42,6 +42,11 @@ module.exports = function (collectionName, records, opts) {
 
     if (that.opts.meta) {
       payload.meta = that.opts.meta;
+      if (opts && opts.meta) {
+        _.merge(payload.meta, opts.meta);
+      }
+    } else if (opts && opts.meta) {
+      payload.meta = opts.meta;
     }
 
     if (_.isArray(records)) {

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -10,7 +10,7 @@ module.exports = function (collectionName, records, opts) {
     function getLinks(links) {
       return _.mapValues(links, function (value) {
         if (_.isFunction(value)) {
-          return value(records);
+          return value(records, opts);
         } else {
           return value;
         }
@@ -23,7 +23,7 @@ module.exports = function (collectionName, records, opts) {
       records.forEach(function (record) {
         var serializerUtils = new SerializerUtils(that.collectionName, record,
           payload, that.opts);
-        payload.data.push(serializerUtils.perform());
+        payload.data.push(serializerUtils.perform(opts));
       });
 
       return payload;

--- a/test/serializer.js
+++ b/test/serializer.js
@@ -1724,4 +1724,52 @@ describe('JSON API Serializer', function () {
       expect(json.data.attributes['empty-string']).to.equal('');
     });
   });
+
+  describe('options provided to serialization', function () {
+    it('should allow meta to be passed in to serialize', function (done) {
+      var dataSet = {
+        id: '1',
+        firstName: 'Sandro',
+        lastName: 'Munda',
+      };
+
+      var meta = {
+        count: 1
+      };
+
+      var json = new JSONAPISerializer('user', {
+        attributes: ['firstName', 'lastName']
+      }).serialize(dataSet, {
+        meta: meta
+      });
+
+      expect(json.meta.count).equal(1);
+      done(null, json);
+    });
+
+    it('should merge constant and provided meta', function (done) {
+      var dataSet = {
+        id: '1',
+        firstName: 'Sandro',
+        lastName: 'Munda',
+      };
+
+      var meta = {
+        count: 1
+      };
+
+      var json = new JSONAPISerializer('user', {
+        attributes: ['firstName', 'lastName'],
+        meta: {
+          offset: 0
+        }
+      }).serialize(dataSet, {
+        meta: meta
+      });
+
+      expect(json.meta.count).equal(1);
+      expect(json.meta.offset).equal(0);
+      done(null, json);
+    });
+  });
 });

--- a/test/serializer.js
+++ b/test/serializer.js
@@ -76,6 +76,47 @@ describe('Options', function () {
     });
   });
 
+  describe('type for relationship', function () {
+    it('should set a related type according to the configuration of the attribute', function (done) {
+      var dataSet = {
+        id: '1',
+        firstName: 'Sandro',
+        lastName: 'Munda',
+        address: [{
+          id: '2',
+          type: 'home',
+          street: 'Dogwood Way',
+          zip: '12345'
+        },{
+          id: '3',
+          type: 'work',
+          street: 'Dogwood Way',
+          zip: '12345'
+        }]
+      };
+
+      var json = new JSONAPISerializer('user', {
+        attributes: ['firstName', 'lastName', 'address'],
+        pluralizeType: false,
+        address: {
+          type: 'overridden',
+          ref: function(user, address) {
+            return address.id;
+          }
+        }
+      }).serialize(dataSet);
+
+      expect(json.included[0]).to.have.property('type').equal('overridden');
+      expect(json.included[1]).to.have.property('type').equal('overridden');
+
+      expect(json.data.relationships).to.have.property('address').that.is.an('object');
+      expect(json.data.relationships.address.data[0]).to.have.property('type').that.is.eql('overridden');
+      expect(json.data.relationships.address.data[1]).to.have.property('type').that.is.eql('overridden');
+
+      done(null, json);
+    });
+  });
+
   describe('typeForAttributeRecord', function () {
     it('should set a related type according to the func return based on the attribute value', function (done) {
       var dataSet = {


### PR DESCRIPTION
Give support for providing an additional options object to the serialize function, and use it for:
- Merging in metadata to the top level meta object (Issue #72)
- Providing per-serialization details - e.g. request specific values - to the various places that links are generated

Both of these make it much easier to have a single instance of the Serializer that can be used with varying data based on the current request.
