### PR TITLE
Fix deserialization of resource objects without ID

### DIFF
--- a/lib/deserializer-utils.js
+++ b/lib/deserializer-utils.js
@@ -68,7 +68,9 @@ module.exports = function (jsonapi, data, opts) {
 
   function extractAttributes(from) {
     var dest = keyForAttribute(from.attributes);
-    dest.id = from.id;
+    if (from.hasOwnProperty('id')) {
+      dest.id = from.id;
+    }
 
     return dest;
   }

--- a/test/deserializer.js
+++ b/test/deserializer.js
@@ -519,4 +519,26 @@ describe('JSON API Deserializer', function () {
       });
     });
   });
+
+  describe('without ID', function () {
+    it('ID should not be returned', function (done) {
+      var dataSet = {
+        data: {
+          type: 'users',
+          attributes: { 'first-name': 'Sandro', 'last-name': 'Munda' }
+        }
+      };
+
+      new JSONAPIDeserializer()
+        .deserialize(dataSet, function (err, json) {
+          expect(json.hasOwnProperty('id')).to.be.false;
+          expect(json).to.be.eql({
+            'first-name': 'Sandro',
+            'last-name': 'Munda'
+          });
+
+          done(null, json);
+        });
+    });
+  });
 });


### PR DESCRIPTION
Fix: ID should not be added to deserialized object if it's not part of JSON API resource object.

Resource objects used to create a resource must not have an ID unless client-side generated IDs are used.