### PR TITLE
Allow deserialization withou data.attributes

### DIFF
--- a/lib/deserializer-utils.js
+++ b/lib/deserializer-utils.js
@@ -67,7 +67,7 @@ module.exports = function (jsonapi, data, opts) {
   }
 
   function extractAttributes(from) {
-    var dest = keyForAttribute(from.attributes);
+    var dest = keyForAttribute(from.attributes || {});
     dest.id = from.id;
 
     return dest;

--- a/test/deserializer.js
+++ b/test/deserializer.js
@@ -518,5 +518,24 @@ describe('JSON API Deserializer', function () {
           });
       });
     });
+
+    describe('Without data.attributes, resource identifier', function() {
+      it('should deserialize an object without data.attributes', function(done) {
+        var dataSet = {
+          data: {
+            type: 'users',
+            id: '54735750e16638ba1eee59cb'
+          }
+        };
+
+        new JSONAPIDeserializer()
+          .deserialize(dataSet, function (err, json) {
+            expect(json).eql({
+              id: '54735750e16638ba1eee59cb'
+            });
+            done(null, json);
+          });
+      });
+    })
   });
 });


### PR DESCRIPTION
When trying to deserialize an object without data.attributes - it fails with `TypeError: Cannot create property 'id' on string 'undefined'`. Passing empty object if attributes not defined.
This is used for resource identifiers: http://jsonapi.org/format/#crud-updating-relationships