### PR TITLE
Bug fix: keyForAttribute() wasn't being called for relationship attributes

### DIFF
--- a/lib/deserializer-utils.js
+++ b/lib/deserializer-utils.js
@@ -88,12 +88,12 @@ module.exports = function (jsonapi, data, opts) {
               return extractIncludes(relationshipData);
             })
             .then(function (includes) {
-              if (includes) { dest[key] = includes; }
+              if (includes) { dest[keyForAttribute(key)] = includes; }
             });
         } else {
           return extractIncludes(relationship.data)
             .then(function (include) {
-              if (include) { dest[key] = include; }
+              if (include) { dest[keyForAttribute(key)] = include; }
             });
         }
       })

--- a/test/deserializer.js
+++ b/test/deserializer.js
@@ -215,6 +215,81 @@ describe('JSON API Deserializer', function () {
       });
     });
 
+    it('should convert relationship attributes to camelCase', function (done) {
+      var dataSet = {
+        data: [{
+          type: 'users',
+          id: '54735750e16638ba1eee59cb',
+          attributes: {
+            'first-name': 'Sandro',
+            'last-name': 'Munda'
+          },
+          relationships: {
+            'my-address': {
+              data: { type: 'addresses', id: '54735722e16620ba1eee36af' }
+            }
+          }
+        }, {
+          type: 'users',
+          id: '5490143e69e49d0c8f9fc6bc',
+          attributes: {
+            'first-name': 'Lawrence',
+            'last-name': 'Bennett'
+          },
+          relationships: {
+            'my-address': {
+              data: { type: 'addresses', id: '54735697e16624ba1eee36bf' }
+            }
+          }
+        }],
+        included: [{
+          type: 'addresses',
+          id: '54735722e16620ba1eee36af',
+          attributes: {
+            'address-line1': '406 Madison Court',
+            'zip-code': '49426',
+            country: 'USA'
+          }
+        }, {
+          type: 'addresses',
+          id: '54735697e16624ba1eee36bf',
+          attributes: {
+            'address-line1': '361 Shady Lane',
+            'zip-code': '23185',
+            country: 'USA'
+          }
+        }]
+      };
+
+      new JSONAPIDeserializer({keyForAttribute: 'camelCase'})
+      .deserialize(dataSet, function (err, json) {
+        expect(json).to.be.an('array').with.length(2);
+
+        expect(json[0]).to.have.key('id', 'firstName', 'lastName',
+          'myAddress');
+        
+        expect(json[0].myAddress).to.be.eql({
+          id: '54735722e16620ba1eee36af',
+          addressLine1: '406 Madison Court',
+          zipCode: '49426',
+          country: 'USA'
+        });
+
+        expect(json[1]).to.have.key('id', 'firstName', 'lastName',
+          'myAddress');
+        
+        expect(json[1].myAddress).to.be.eql({
+          id: '54735697e16624ba1eee36bf',
+          addressLine1: '361 Shady Lane',
+          zipCode: '23185',
+          country: 'USA'
+        });
+
+        done(null, json);
+      });
+      
+    });
+  
     describe('With multiple levels', function () {
       it('should merge all include relationships to attributes', function (done) {
         var dataSet = {


### PR DESCRIPTION
**Bug fix:** `keyForAttribute()` wasn't being called for relationship attributes. This meant that even if the `keyForAttribute` setting was specified in the Deserializer options, all relationship attributes were staying as dash-case.

An example of this would be having a relationship attribute of `my-address` (instead of just `address`). When specifying `keyForAttribute: 'camelCase'`in the Deserializer options, regular attributes would be converted to camelCase but relationship attributes would remain as the default dash-case. I used this example in the new test I've included.