### PR TITLE
enforce IDs to be string for ref: true

### DIFF
--- a/lib/serializer-utils.js
+++ b/lib/serializer-utils.js
@@ -37,7 +37,13 @@ module.exports = function (collectionName, record, payload, opts) {
     if (_.isFunction(opts.ref)) {
       return opts.ref(current, item);
     } else if (opts.ref === true) {
-      return item;
+      if (_.isArray(item)) {
+        return item.map(function (val) {
+          return String(val);
+        });
+      } else {
+        return String(item);
+      }
     } else {
       return String(item[opts.ref]);
     }

--- a/test/serializer.js
+++ b/test/serializer.js
@@ -1832,6 +1832,48 @@ describe('JSON API Serializer', function () {
 
       done(null, json);
     });
+
+    it('should convert IDs to string', function (done) {
+      var dataSet = [{
+        id: '54735750e16638ba1eee59cb',
+        firstName: 'Sandro',
+        lastName: 'Munda',
+        address: [5]
+      }];
+
+      var json = new JSONAPISerializer('users', {
+        attributes: ['firstName', 'lastName', 'address'],
+        address: {
+          ref: true
+        }
+      }).serialize(dataSet);
+
+      expect(json.data[0].relationships.address.data[0].id).to
+        .equal('5');
+
+      done(null, json);
+    });
+
+    it('should convert ID to string', function (done) {
+      var dataSet = {
+        id: '54735750e16638ba1eee59cb',
+        firstName: 'Sandro',
+        lastName: 'Munda',
+        address: 10
+      };
+
+      var json = new JSONAPISerializer('users', {
+        attributes: ['firstName', 'lastName', 'address'],
+        address: {
+          ref: true
+        }
+      }).serialize(dataSet);
+
+      expect(json.data.relationships.address.data.id).to
+        .equal('10');
+
+      done(null, json);
+    });
   });
 
 });


### PR DESCRIPTION
> Identification
>
> Every resource object MUST contain an id member and a type member.
> The values of the id and type members MUST be strings.
http://jsonapi.org/format/#document-resource-object-identification