### PR TITLE
Filter out null relationships from included

### DIFF
--- a/lib/serializer-utils.js
+++ b/lib/serializer-utils.js
@@ -181,8 +181,10 @@ module.exports = function (collectionName, record, payload, opts) {
       if (opts.includedLinks) {
         included.links = getLinks(dest, opts.includedLinks);
       }
-
-      pushToIncluded(payload, included);
+      // only add to included array if the resource is defined
+      if(id !== 'undefined') {
+        pushToIncluded(payload, included);
+      }
     }
 
     return id !== 'undefined' ? { type: type, id: id } : null;

--- a/test/serializer.js
+++ b/test/serializer.js
@@ -1630,6 +1630,41 @@ describe('JSON API Serializer', function () {
       done(null, json);
     });
 
+    it('should not add a resource to included for null `data` relationship', function (done) {
+      var dataSet = [{
+        id: '54735750e16638ba1eee59cb',
+        firstName: 'Sandro',
+        lastName: 'Munda',
+        address: {
+          id: '54735722e16620ba1eee36af',
+          addressLine1: '406 Madison Court',
+          zipCode: '49426',
+          country: 'USA'
+        },
+      }, {
+        id: '5490143e69e49d0c8f9fc6bc',
+        firstName: 'Lawrence',
+        lastName: 'Bennett',
+        address: {}
+      }];
+
+      var json = new JSONAPISerializer('users', {
+        attributes: ['firstName', 'lastName', 'address'],
+        address: {
+          ref: 'id',
+          attributes: ['addressLine1', 'zipCode', 'country']
+        },
+      }).serialize(dataSet);
+
+      expect(json.data[0].relationships.address.data).to.be.an('object');
+      expect(json.data[1].relationships.address.data).to.equal(null);
+      expect(json).to.have.property('included').to.be.an('array').with
+        .length(1);
+      expect(json.included[0].id).to.equal('54735722e16620ba1eee36af');
+
+      done(null, json);
+    });
+
     it('should have an empty array for the `data` attribute when relationship is many-to', function (done) {
       var dataSet = [{
         id: '54735750e16638ba1eee59cb',


### PR DESCRIPTION
This change lets you define a serializer that can parse included out of relationship data while gracefully handling null relationships.


Currently, for null relationships, included has data that looks like this:
```json
{
  "type": "addresses",
  "id": "undefined",
  "attributes": {}
}
```

Before change:
```js
[{
  id: '54735750e16638ba1eee59cb',
  firstName: 'Sandro',
  lastName: 'Munda',
  address: {
    id: '54735722e16620ba1eee36af',
    addressLine1: '406 Madison Court',
    zipCode: '49426',
    country: 'USA'
  },
}, {
  id: '5490143e69e49d0c8f9fc6bc',
  firstName: 'Lawrence',
  lastName: 'Bennett',
  address: {}
}]
```

output:
```json
{
  "data": [
    {
      "type": "users",
      "id": "54735750e16638ba1eee59cb",
      "attributes": {
        "first-name": "Sandro",
        "last-name": "Munda"
      },
      "relationships": {
        "address": {
          "data": {
            "type": "addresses",
            "id": "54735722e16620ba1eee36af"
          }
        }
      }
    },
    {
      "type": "users",
      "id": "5490143e69e49d0c8f9fc6bc",
      "attributes": {
        "first-name": "Lawrence",
        "last-name": "Bennett"
      },
      "relationships": {
        "address": {
          "data": null
        }
      }
    }
  ],
  "included": [
    {
      "type": "addresses",
      "id": "54735722e16620ba1eee36af",
      "attributes": {
        "address-line1": "406 Madison Court",
        "zip-code": "49426",
        "country": "USA"
      }
    },
    {
      "type": "addresses",
      "id": "undefined",
      "attributes": {}
    }
  ]
}
```