### PR TITLE
Deserialize: support empty relationships

### DIFF
--- a/lib/deserializer-utils.js
+++ b/lib/deserializer-utils.js
@@ -82,7 +82,9 @@ module.exports = function (jsonapi, data, opts) {
       .each(Object.keys(from.relationships), function (key) {
         var relationship = from.relationships[key];
 
-        if (_.isArray(relationship.data)) {
+        if (relationship.data === null) {
+          dest[keyForAttribute(key)] = null;
+        } else if (_.isArray(relationship.data)) {
           return P
             .map(relationship.data, function (relationshipData) {
               return extractIncludes(relationshipData);

--- a/test/deserializer.js
+++ b/test/deserializer.js
@@ -566,8 +566,8 @@ describe('JSON API Deserializer', function () {
       });
     });
 
-    describe('With null data relationship', function () {
-      it('should ignore the relationship', function (done) {
+    describe('With empty relationship', function () {
+      it('should include the relationship as null (one-to)', function (done) {
         var dataSet = {
           data: {
             type: 'users',
@@ -587,7 +587,35 @@ describe('JSON API Deserializer', function () {
             expect(json).eql({
               id: '54735750e16638ba1eee59cb',
               'first-name': 'Sandro',
+              'last-name': 'Munda',
+              'address': null
+            });
+            done(null, json);
+          });
+      });
+
+      it('should include the relationship as empty array (to-many)', function (done) {
+        var dataSet = {
+          data: {
+            type: 'users',
+            id: '54735750e16638ba1eee59cb',
+            attributes: {
+              'first-name': 'Sandro',
               'last-name': 'Munda'
+            },
+            relationships: {
+              addresses: { data: [] }
+            }
+          }
+        };
+
+        new JSONAPIDeserializer()
+          .deserialize(dataSet, function (err, json) {
+            expect(json).eql({
+              id: '54735750e16638ba1eee59cb',
+              'first-name': 'Sandro',
+              'last-name': 'Munda',
+              'addresses': []
             });
             done(null, json);
           });
@@ -619,7 +647,7 @@ describe('JSON API Deserializer', function () {
                 id: '2e593a7f2c3f2e5fc0b6ea1d4f03a2a3',
                 type: 'address',
                 attributes: {
-                  'state': 'Alabama', 
+                  'state': 'Alabama',
                   'zip-code': '35801'
                 },
                 relationships: {
@@ -640,7 +668,8 @@ describe('JSON API Deserializer', function () {
               'address': {
                 'id': '2e593a7f2c3f2e5fc0b6ea1d4f03a2a3',
                 'state': 'Alabama',
-                'zip-code': '35801'
+                'zip-code': '35801',
+                'telephone': null
               }
             });
             done(null, json);


### PR DESCRIPTION
Keep information if a relationship is empty.
Following JSON API spec:
> Resource linkage MUST be represented as one of the following:
> * null for empty to-one relationships.
> * an empty array ([]) for empty to-many relationships.
> http://jsonapi.org/format/#document-resource-object-linkage