### PR TITLE
Add 'id' option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Calling the `serialize` method on the returned object will serialize your `data`
 - *attributes*: An array of attributes to show. You can define an attribute as an option if you want to define some relationships (included or not).
     - *ref*: If present, it's considered as a relationships.
     - *included*: Consider the relationships as [compound document](http://jsonapi.org/format/#document-compound-documents). Default: true.
+    - *id*: Configurable identifier field for the resource. Default: `id`.
     - *attributes*: An array of attributes to show.
     - *topLevelLinks*: An object that describes the top-level links. Values can be *string* or a *function* (see examples below)
     - *dataLinks*: An object that describes the links inside data. Values can be *string* or a *function* (see examples below)


### PR DESCRIPTION
Was investigating using this module for a project and needed to configure id's for my resources. Didn't see the option listed in the README, but took a look at the source code and saw that there was a reference to an `id` option (https://github.com/SeyZ/jsonapi-serializer/blob/8cf41088760c2b0362093af7e70953ac91b7dc15/lib/serializer-utils.js#L36-L38), so I've added it to the REAMDE.

The actual text description is up for debate - just went with something I thought sounded good :)