### PR TITLE
modularize lodash method requires

### DIFF
--- a/lib/deserializer-utils.js
+++ b/lib/deserializer-utils.js
@@ -138,8 +138,6 @@ module.exports = function (jsonapi, data, opts) {
   this.perform = function () {
     return Promise
       .all([extractAttributes(data), extractRelationships(data)])
-      .spread(function (attributes, relationships) {
-        return _extend(attributes, relationships);
       .then(function (results) {
         var attributes = results[0];
         var relationships = results[1];

--- a/lib/deserializer-utils.js
+++ b/lib/deserializer-utils.js
@@ -1,11 +1,15 @@
 'use strict';
 var P = require('bluebird');
-var _ = require('lodash');
+var isPlainObject = require('lodash/isPlainObject');
+var isFunction = require('lodash/isFunction');
+var _find = require('lodash/find');
+var _extend = require('lodash/extend');
+var _transform = require('lodash/transform');
 var Inflector = require('./inflector');
 
 module.exports = function (jsonapi, data, opts) {
   function isComplexType(obj) {
-    return _.isArray(obj) || _.isPlainObject(obj);
+    return Array.isArray(obj) || isPlainObject(obj);
   }
 
   function getValueForRelationship(relationshipData, included) {
@@ -23,7 +27,7 @@ module.exports = function (jsonapi, data, opts) {
     return new P(function (resolve) {
       if (!jsonapi.included || !relationshipData) { resolve(null); }
 
-      var included = _.find(jsonapi.included, {
+      var included = _find(jsonapi.included, {
         id: relationshipData.id,
         type: relationshipData.type
       });
@@ -32,7 +36,7 @@ module.exports = function (jsonapi, data, opts) {
         return P
           .all([extractAttributes(included), extractRelationships(included)])
           .spread(function (attributes, relationships) {
-            resolve(_.extend(attributes, relationships));
+            resolve(_extend(attributes, relationships));
           });
       } else {
         return resolve(null);
@@ -41,15 +45,15 @@ module.exports = function (jsonapi, data, opts) {
   }
 
   function keyForAttribute(attribute) {
-    if (_.isPlainObject(attribute)) {
-      return _.transform(attribute, function (result, value, key) {
+    if (isPlainObject(attribute)) {
+      return _transform(attribute, function (result, value, key) {
         if (isComplexType(value)) {
           result[keyForAttribute(key)] = keyForAttribute(value);
         } else {
           result[keyForAttribute(key)] = value;
         }
       });
-    } else if (_.isArray(attribute)) {
+    } else if (Array.isArray(attribute)) {
       return attribute.map(function (attr) {
         if (isComplexType(attr)) {
           return keyForAttribute(attr);
@@ -58,7 +62,7 @@ module.exports = function (jsonapi, data, opts) {
         }
       });
     } else {
-      if (_.isFunction(opts.keyForAttribute)) {
+      if (isFunction(opts.keyForAttribute)) {
         return opts.keyForAttribute(attribute);
       } else {
         return Inflector.caserize(attribute, opts);
@@ -84,7 +88,7 @@ module.exports = function (jsonapi, data, opts) {
 
         if (relationship.data === null) {
           dest[keyForAttribute(key)] = null;
-        } else if (_.isArray(relationship.data)) {
+        } else if (Array.isArray(relationship.data)) {
           return P
             .map(relationship.data, function (relationshipData) {
               return extractIncludes(relationshipData);
@@ -108,7 +112,7 @@ module.exports = function (jsonapi, data, opts) {
         var valueForRelationship = getValueForRelationship(relationshipData,
           included);
 
-        if (valueForRelationship && _.isFunction(valueForRelationship.then)) {
+        if (valueForRelationship && isFunction(valueForRelationship.then)) {
           return valueForRelationship.then(function (value) {
             return value;
           });
@@ -122,7 +126,7 @@ module.exports = function (jsonapi, data, opts) {
     return P
       .all([extractAttributes(data), extractRelationships(data)])
       .spread(function (attributes, relationships) {
-        return _.extend(attributes, relationships);
+        return _extend(attributes, relationships);
       });
   };
 };

--- a/lib/deserializer.js
+++ b/lib/deserializer.js
@@ -1,5 +1,5 @@
 'use strict';
-var _ = require('lodash');
+var isFunction = require('lodash/isFunction');
 var P = require('bluebird');
 var DeserializerUtils = require('./deserializer-utils');
 
@@ -13,10 +13,10 @@ module.exports = function (opts) {
           return new DeserializerUtils(jsonapi, d, opts).perform();
         })
         .then(function (result) {
-          if (_.isFunction(callback)) {
+          if (isFunction(callback)) {
             callback(null, result);
           }
-          
+
           return result
         });
     }
@@ -25,7 +25,7 @@ module.exports = function (opts) {
       return new DeserializerUtils(jsonapi, jsonapi.data, opts)
         .perform()
         .then(function (result) {
-          if (_.isFunction(callback)) {
+          if (isFunction(callback)) {
             callback(null, result);
           }
 
@@ -33,7 +33,7 @@ module.exports = function (opts) {
         });
     }
 
-    if (_.isArray(jsonapi.data)) {
+    if (Array.isArray(jsonapi.data)) {
       return collection();
     } else {
       return resource();

--- a/lib/serializer-utils.js
+++ b/lib/serializer-utils.js
@@ -1,22 +1,31 @@
 'use strict';
-var _ = require('lodash');
+var isPlainObject = require('lodash/isPlainObject');
+var isFunction = require('lodash/isFunction');
+var _find = require('lodash/find');
+var _extend = require('lodash/extend');
+var _transform = require('lodash/transform');
+var _mapValues = require('lodash/mapValues');
+var _mapKeys = require('lodash/mapKeys');
+var _pick = require('lodash/pick');
+var _keys = require('lodash/keys');
+var _each = require('lodash/each');
 var Inflector = require('./inflector');
 
 module.exports = function (collectionName, record, payload, opts) {
   function isComplexType(obj) {
-    return _.isArray(obj) || _.isPlainObject(obj);
+    return Array.isArray(obj) || isPlainObject(obj);
   }
 
   function keyForAttribute(attribute) {
-    if (_.isPlainObject(attribute)) {
-      return _.transform(attribute, function (result, value, key) {
+    if (isPlainObject(attribute)) {
+      return _transform(attribute, function (result, value, key) {
         if (isComplexType(value)) {
           result[keyForAttribute(key)] = keyForAttribute(value);
         } else {
           result[keyForAttribute(key)] = value;
         }
       });
-    } else if (_.isArray(attribute)) {
+    } else if (Array.isArray(attribute)) {
       return attribute.map(function (attr) {
         if (isComplexType(attr)) {
           return keyForAttribute(attr);
@@ -25,7 +34,7 @@ module.exports = function (collectionName, record, payload, opts) {
         }
       });
     } else {
-      if (_.isFunction(opts.keyForAttribute)) {
+      if (isFunction(opts.keyForAttribute)) {
         return opts.keyForAttribute(attribute);
       } else {
         return Inflector.caserize(attribute, opts);
@@ -38,10 +47,10 @@ module.exports = function (collectionName, record, payload, opts) {
   }
 
   function getRef(current, item, opts) {
-    if (_.isFunction(opts.ref)) {
+    if (isFunction(opts.ref)) {
       return opts.ref(current, item);
     } else if (opts.ref === true) {
-      if (_.isArray(item)) {
+      if (Array.isArray(item)) {
         return item.map(function (val) {
           return String(val);
         });
@@ -57,16 +66,16 @@ module.exports = function (collectionName, record, payload, opts) {
     var type;
     attrVal = attrVal || {};
 
-    if (_.isFunction(opts.typeForAttribute)) {
+    if (isFunction(opts.typeForAttribute)) {
       type = opts.typeForAttribute(str, attrVal);
     }
 
     // If the pluralize option is on, typeForAttribute returned undefined or wasn't used
-    if ((_.isUndefined(opts.pluralizeType) || opts.pluralizeType) && _.isUndefined(type)) {
+    if ((opts.pluralizeType === undefined || opts.pluralizeType) && type === undefined) {
       type = Inflector.pluralize(str);
     }
 
-    if (_.isUndefined(type)) {
+    if (type === undefined) {
       type = str;
     }
 
@@ -74,8 +83,8 @@ module.exports = function (collectionName, record, payload, opts) {
   }
 
   function getLinks(current, links, dest) {
-    return _.mapValues(links, function (value) {
-      if (_.isFunction(value)) {
+    return _mapValues(links, function (value) {
+      if (isFunction(value)) {
         return value(record, current, dest);
       } else {
         return value;
@@ -84,8 +93,8 @@ module.exports = function (collectionName, record, payload, opts) {
   }
 
   function getMeta(current, meta) {
-    return _.mapValues(meta, function (value) {
-      if (_.isFunction(value)) {
+    return _mapValues(meta, function (value) {
+      if (isFunction(value)) {
         return value(record, current);
       } else {
         return value;
@@ -94,13 +103,13 @@ module.exports = function (collectionName, record, payload, opts) {
   }
 
   function pick(obj, attributes) {
-    return _.mapKeys(_.pick(obj, attributes), function (value, key) {
+    return _mapKeys(_pick(obj, attributes), function (value, key) {
       return keyForAttribute(key);
     });
   }
 
   function isCompoundDocumentIncluded(included, item) {
-    return _.find(payload.included, { id: item.id, type: item.type });
+    return _find(payload.included, { id: item.id, type: item.type });
   }
 
   function pushToIncluded(dest, include) {
@@ -117,7 +126,7 @@ module.exports = function (collectionName, record, payload, opts) {
     if (opts && opts.ref) {
       if (!dest.relationships) { dest.relationships = {}; }
 
-      if (_.isArray(current[attribute])) {
+      if (Array.isArray(current[attribute])) {
         data = current[attribute].map(function (item) {
           return that.serializeRef(item, current, attribute, opts);
         });
@@ -141,8 +150,8 @@ module.exports = function (collectionName, record, payload, opts) {
           getMeta(current[attribute], opts.relationshipMeta);
       }
     } else {
-      if (_.isArray(current[attribute])) {
-        if (current[attribute].length && _.isPlainObject(current[attribute][0])) {
+      if (Array.isArray(current[attribute])) {
+        if (current[attribute].length && isPlainObject(current[attribute][0])) {
           data = current[attribute].map(function (item) {
             return that.serializeNested(item, current, attribute, opts);
           });
@@ -151,7 +160,7 @@ module.exports = function (collectionName, record, payload, opts) {
         }
 
         dest.attributes[keyForAttribute(attribute)] = data;
-      } else if (_.isPlainObject(current[attribute])) {
+      } else if (isPlainObject(current[attribute])) {
         data = that.serializeNested(current[attribute], current, attribute, opts);
         dest.attributes[keyForAttribute(attribute)] = data;
       } else {
@@ -188,7 +197,7 @@ module.exports = function (collectionName, record, payload, opts) {
     });
 
     if (includedAttrs.length &&
-      (_.isUndefined(opts.included) || opts.included)) {
+      (opts.included === undefined || opts.included)) {
       if (opts.includedLinks) {
         included.links = getLinks(dest, opts.includedLinks);
       }
@@ -214,7 +223,7 @@ module.exports = function (collectionName, record, payload, opts) {
         return !opts[attr];
       });
     } else {
-      attributes = _.keys(dest);
+      attributes = _keys(dest);
     }
 
     var ret = {};
@@ -232,7 +241,7 @@ module.exports = function (collectionName, record, payload, opts) {
   this.perform = function () {
     var that = this;
 
-    if( _.isNull( record ) ){
+    if( record === null ){
         return null;
     }
 
@@ -247,7 +256,7 @@ module.exports = function (collectionName, record, payload, opts) {
       data.links = getLinks(record, opts.dataLinks);
     }
 
-    _.each(opts.attributes, function (attribute) {
+    _each(opts.attributes, function (attribute) {
       var splittedAttributes = attribute.split(':');
 
       if (splittedAttributes[0] in record ||

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -1,5 +1,6 @@
 'use strict';
-var _ = require('lodash');
+var isFunction = require('lodash/isFunction');
+var _mapValues = require('lodash/mapValues');
 var SerializerUtils = require('./serializer-utils');
 
 module.exports = function (collectionName, records, opts) {
@@ -8,8 +9,8 @@ module.exports = function (collectionName, records, opts) {
     var payload = {};
 
     function getLinks(links) {
-      return _.mapValues(links, function (value) {
-        if (_.isFunction(value)) {
+      return _mapValues(links, function (value) {
+        if (isFunction(value)) {
           return value(records);
         } else {
           return value;
@@ -44,7 +45,7 @@ module.exports = function (collectionName, records, opts) {
       payload.meta = that.opts.meta;
     }
 
-    if (_.isArray(records)) {
+    if (Array.isArray(records)) {
       return collection(records);
     } else {
       return resource(records);


### PR DESCRIPTION
use `var isFunction = require('lodash/isFunction`) instead of just `var _ = require('lodash')` - #123 

- also cleaned up usage of isNull, isUndefined, isArray
  - `isNull` in lodash just does `thing === null` [link](https://github.com/lodash/lodash/blob/4.17.4/lodash.js#L11963)
  - `isUndefined` in lodash just does `thing === undefined` [link](https://github.com/lodash/lodash/blob/4.17.4/lodash.js#L12212)
  - `isArray` in lodash just uses `Array.isArray` [link](https://github.com/lodash/lodash/blob/4.17.4/lodash.js#L11300)