### PR TITLE
JSON API errors support

### DIFF
--- a/lib/error/JSONAPIError.js
+++ b/lib/error/JSONAPIError.js
@@ -1,9 +1,9 @@
 var http = require('http');
 
 module.exports = function (
-  status = 500, detail = '', code = '', id = '',
-  meta = {}, sourcePointer = '', sourceParameter = '',
-  linksAbout = ''
+  status, detail, code, id,
+  meta, sourcePointer, sourceParameter,
+  linksAbout
 ) {
   if (typeof status === 'undefined') {
     status = 500;

--- a/lib/error/JSONAPIError.js
+++ b/lib/error/JSONAPIError.js
@@ -5,8 +5,30 @@ module.exports = function (
   meta = {}, sourcePointer = '', sourceParameter = '',
   linksAbout = ''
 ) {
-  if (typeof detail === 'object') {
-    return detail;
+  var rawParamObj = null;
+
+  if (typeof status === 'object') {
+    rawParamObj = status;
+  } else if (typeof detail === 'object') {
+    rawParamObj = detail;
+  }
+
+  if (rawParamObj !== null) {
+    id = rawParamObj.id || '';
+    if (Object.prototype.hasOwnProperty.call(rawParamObj, 'links')) {
+      linksAbout = rawParamObj.links.about || '';
+    }
+    status = rawParamObj.status || 500;
+    code = rawParamObj.code || '';
+    detail = rawParamObj.detail || '';
+    if (Object.prototype.hasOwnProperty.call(rawParamObj, 'source')) {
+      sourcePointer = rawParamObj.source.pointer || '';
+      sourceParameter = rawParamObj.source.parameter || '';
+    } else {
+      sourcePointer = '';
+      sourceParameter = '';
+    }
+    meta = rawParamObj.meta || {};
   }
 
   var error = {};

--- a/lib/error/JSONAPIError.js
+++ b/lib/error/JSONAPIError.js
@@ -1,0 +1,52 @@
+var http = require('http');
+
+module.exports = function (
+  status = 500, detail = '', code = '', id = '',
+  meta = {}, sourcePointer = '', sourceParameter = '',
+  linksAbout = ''
+) {
+  if (typeof detail === 'object') {
+    return detail;
+  }
+
+  var error = {};
+
+  if (id !== '') {
+    error.id = id.toString();
+  }
+
+  if (linksAbout !== '') {
+    error.links = error.links || {};
+
+    error.links.about = linksAbout;
+  }
+
+  error.status = status.toString();
+
+  if (code !== '') {
+    error.code = code.toString();
+  }
+
+  error.title = http.STATUS_CODES[parseInt(status)];
+
+  if (detail !== '') {
+    error.detail = detail.toString();
+  }
+
+  if (sourcePointer !== '') {
+    error.source = error.source || {};
+
+    error.source.pointer = sourcePointer.toString();
+  }
+  if (sourceParameter !== '') {
+    error.source = error.source || {};
+
+    error.source.parameter = sourceParameter.toString();
+  }
+
+  if (Object.getOwnPropertyNames(meta).length !== 0) {
+    error.meta = meta;
+  }
+
+  return error;
+};

--- a/lib/error/JSONAPIError.js
+++ b/lib/error/JSONAPIError.js
@@ -5,6 +5,39 @@ module.exports = function (
   meta = {}, sourcePointer = '', sourceParameter = '',
   linksAbout = ''
 ) {
+  if (typeof status === 'undefined') {
+    status = 500;
+  }
+
+  if (typeof detail === 'undefined') {
+    detail = '';
+  }
+
+  if (typeof code === 'undefined') {
+    code = '';
+  }
+
+  if (typeof id === 'undefined') {
+    id = '';
+  }
+
+  if (typeof meta === 'undefined') {
+    meta = {};
+  }
+
+  if (typeof sourcePointer === 'undefined') {
+    sourcePointer = '';
+  }
+
+  if (typeof sourceParameter === 'undefined') {
+    sourceParameter = '';
+  }
+
+  if (typeof linksAbout === 'undefined') {
+    linksAbout = '';
+  }
+
+
   var rawParamObj = null;
 
   if (typeof status === 'object') {
@@ -30,6 +63,7 @@ module.exports = function (
     }
     meta = rawParamObj.meta || {};
   }
+
 
   var error = {};
 

--- a/lib/error/NotFound.js
+++ b/lib/error/NotFound.js
@@ -1,0 +1,12 @@
+var http = require('http');
+var JSONAPIError = require('./JSONAPIError');
+
+var STATUS_CODE = 404;
+
+module.exports = function (
+  detailOrExplicit = '', code = '', id = '', meta = {},
+  sourcePointer = '', sourceParameter = '', linksAbout = ''
+) {
+  return new JSONAPIError(
+    STATUS_CODE, detailOrExplicit, code, id, meta, sourcePointer, sourceParameter, linksAbout);
+};

--- a/lib/error/NotFound.js
+++ b/lib/error/NotFound.js
@@ -4,8 +4,8 @@ var JSONAPIError = require('./JSONAPIError');
 var STATUS_CODE = 404;
 
 module.exports = function (
-  detailOrExplicit = '', code = '', id = '', meta = {},
-  sourcePointer = '', sourceParameter = '', linksAbout = ''
+  detailOrExplicit, code, id, meta,
+  sourcePointer, sourceParameter, linksAbout
 ) {
   return new JSONAPIError(
     STATUS_CODE, detailOrExplicit, code, id, meta, sourcePointer, sourceParameter, linksAbout);

--- a/lib/error/handler.js
+++ b/lib/error/handler.js
@@ -1,0 +1,9 @@
+module.exports = function (err, req, res, next) {
+  if (res.headersSent) {
+    return next(err);
+  }
+
+  return res
+    .status(parseInt(err.status) || 500)
+    .json({ errors: err });
+};

--- a/test/error.js
+++ b/test/error.js
@@ -1,0 +1,148 @@
+'use strict';
+/* global describe, it */
+
+var chai = require('chai');
+var assert = chai.assert;
+var expect = chai.expect;
+
+var http = require('http');
+
+var JSONAPIError = require('../lib/error/JSONAPIError');
+var NotFound = require('../lib/error/NotFound');
+
+describe('Errors', function () {
+
+  describe('Status', function () {
+    it('should set HTTP status code 500 by default', function (done) {
+      var error = new JSONAPIError();
+
+      assert(error.status === '500', 'Wrong HTTP status code');
+
+      done(null, error);
+    });
+
+    it('should set HTTP status code', function (done) {
+      var error = new JSONAPIError(415);
+
+      assert(error.status === '415', 'Wrong HTTP status code');
+
+      done(null, error);
+    });
+
+    it('should set HTTP status title', function (done) {
+      var error = NotFound('detail', 'code', 'id');
+
+      assert(error.title === http.STATUS_CODES[404], 'Wrong HTTP status title');
+
+      done(null, error);
+    });
+  });
+
+  describe('Title', function () {
+    it('SHOULD NOT change from occurrence to occurrence ', function (done) {
+      var error1 = NotFound('detail1', 'code1', 'id1');
+      var error2 = NotFound('detail2', 'code2', 'id2');
+
+      assert(error1.title === error2.title, 'Titles are different');
+
+      done(null, error1);
+    });
+  });
+
+  describe('JSON API compliant "errors" object', function () {
+    it('should handled undefined keys properly', function (done) {
+      var error = NotFound();
+
+      var result = {
+        status: '404',
+        title: http.STATUS_CODES[404],
+      };
+
+      expect(error).to.be.eql(result);
+
+      done(null, error);
+    });
+
+    it('should handled empty keys properly', function (done) {
+      var error = NotFound('', '', '', {});
+
+      var result = {
+        status: '404',
+        title: http.STATUS_CODES[404],
+      };
+
+      expect(error).to.be.eql(result);
+
+      done(null, error);
+    });
+
+    it('should set string keys properly', function (done) {
+      var error = NotFound('detail', 'code', 'id');
+
+      var result = {
+        id: 'id',
+        status: '404',
+        code: 'code',
+        title: http.STATUS_CODES[404],
+        detail: 'detail',
+      };
+
+      expect(error).to.be.eql(result);
+
+      done(null, error);
+    });
+
+    it('should set "meta" properly', function (done) {
+      var error = NotFound('detail', '', '', { foo: 'bar' });
+
+      var result = {
+        status: '404',
+        title: http.STATUS_CODES[404],
+        detail: 'detail',
+        meta: {
+          foo: 'bar',
+        }
+      };
+
+      expect(error).to.be.eql(result);
+
+      done(null, error);
+    });
+
+    it('should set "source" properly', function (done) {
+      var error = NotFound('', 'code', '', {}, '/data/pointer', 'param');
+
+      var result = {
+        status: '404',
+        code: 'code',
+        title: http.STATUS_CODES[404],
+        source: {
+          pointer: '/data/pointer',
+          parameter: 'param'
+        }
+      };
+
+      expect(error).to.be.eql(result);
+
+      done(null, error);
+    });
+
+    it('should set "links" properly', function (done) {
+      var error = NotFound('', 'code', '', {}, '', '', '//foo.bar/errors/baz');
+
+      var result = {
+        status: '404',
+        code: 'code',
+        title: http.STATUS_CODES[404],
+        links: {
+          about: '//foo.bar/errors/baz',
+        }
+      };
+
+      expect(error).to.be.eql(result);
+
+      done(null, error);
+    });
+  });
+
+});

--- a/test/error.js
+++ b/test/error.js
@@ -13,7 +13,7 @@ var NotFound = require('../lib/error/NotFound');
 describe('Errors', function () {
 
   describe('Status', function () {
-    it('should set HTTP status code 500 by default', function (done) {
+    it('should set HTTP status code 500 by implicit default', function (done) {
       var error = new JSONAPIError();
 
       assert(error.status === '500', 'Wrong HTTP status code');
@@ -21,10 +21,30 @@ describe('Errors', function () {
       done(null, error);
     });
 
-    it('should set HTTP status code', function (done) {
+    it('should set HTTP status code 500 by explicit default', function (done) {
+      var error = new JSONAPIError({
+        'id': 'id',
+      });
+
+      assert(error.status === '500', 'Wrong HTTP status code');
+
+      done(null, error);
+    });
+
+    it('should set implicit HTTP status code', function (done) {
       var error = new JSONAPIError(415);
 
       assert(error.status === '415', 'Wrong HTTP status code');
+
+      done(null, error);
+    });
+
+    it('should set HTTP status title from status code', function (done) {
+      var error = new JSONAPIError({
+        status: 404
+      });
+
+      assert(error.title === http.STATUS_CODES[404], 'Wrong HTTP status code');
 
       done(null, error);
     });


### PR DESCRIPTION
- Basic error support via  
`return next(new JSONAPIError({ id: '1', status: 415 }));`,
`return next(new JSONAPIError(415, '', '', '1'));`,
`return next(NotFound({ code: '0xABBA', status: '404' }));`, or
`return next(NotFound('', '0xABBA'));`
- Automatically set the 'title' property in order to sustain compliancy.
- No support for multiple errors (yet).
- Error handler middleware to wrap things up and do a final touch.
- Tests are written, can be populated upon request.

Any thoughts?