### PR TITLE
update data meta test

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Calling the `serialize` method on the returned object will serialize your `data`
 
 - [Express example](https://github.com/SeyZ/jsonapi-serializer/tree/master/examples/express)
 - [Simple usage](#simple-usage-serializer)
-- [More example](https://github.com/SeyZ/jsonapi-serializer/blob/master/test/serializer.js)
+- [More examples in tests](https://github.com/SeyZ/jsonapi-serializer/blob/master/test/serializer.js)
 
 <a name="simple-usage-serializer"></a>
 Simple usage:
@@ -122,7 +122,7 @@ Calling the `deserialize` method on the returned object will deserialize your `d
 
 - [Simple usage](#simple-usage-deserializer)
 - [Relationship](#relationship-deserializer)
-- [More example](https://github.com/SeyZ/jsonapi-serializer/blob/master/test/deserializer.js)
+- [More examples in tests](https://github.com/SeyZ/jsonapi-serializer/blob/master/test/deserializer.js)
 
 <a name="simple-usage-deserializer"></a>
 Simple usage:

--- a/test/serializer.js
+++ b/test/serializer.js
@@ -176,7 +176,7 @@ describe('Options', function () {
     });
   });
 
-  describe('Top level meta', function () {
+  describe('Top level meta option', function () {
     it('should set the meta key (plain value)', function (done) {
       var dataSet = {
         id: '1',
@@ -222,8 +222,38 @@ describe('Options', function () {
     });
   });
 
-  describe('meta', function () {
+  describe('dataMeta option', function () {
     it('should set the meta key to each data records (plain value)', function (done) {
+      var dataSet = [{
+        id: '54735750e16638ba1eee59cb',
+        firstName: 'Sandro',
+        lastName: 'Munda',
+        books: [
+          { createdAt: '2015-08-04T06:09:24.864Z' },
+          { createdAt: '2015-08-04T07:09:24.864Z' }
+        ]
+      }, {
+        id: '5490143e69e49d0c8f9fc6bc',
+        firstName: 'Lawrence',
+        lastName: 'Bennett',
+        books: [
+          { createdAt: '2015-09-04T06:10:24.864Z' }
+        ]
+      }];
+
+      var json = new JSONAPISerializer('user', {
+        attributes: ['firstName', 'lastName'],
+        dataMeta: {
+          copyright: 'publisher'
+        }
+      }).serialize(dataSet);
+
+      expect(json.data[0].meta.copyright).equal('publisher');
+      expect(json.data[1].meta.copyright).equal('publisher');
+      done(null, json);
+    });
+
+    it('should set the meta key to each data records (function)', function (done) {
       var dataSet = [{
         id: '54735750e16638ba1eee59cb',
         firstName: 'Sandro',
@@ -252,32 +282,6 @@ describe('Options', function () {
 
       expect(json.data[0].meta.count).equal(2);
       expect(json.data[1].meta.count).equal(1);
-      done(null, json);
-    });
-
-    it('should set the meta key (function)', function (done) {
-      var dataSet = {
-        id: '1',
-        firstName: 'Sandro',
-        lastName: 'Munda',
-      };
-
-      var json = new JSONAPISerializer('user', {
-        attributes: ['firstName', 'lastName'],
-        meta: {
-          count: function (record) {
-            expect(record).to.be.eql({
-              id: '1',
-              firstName: 'Sandro',
-              lastName: 'Munda',
-            });
-
-            return 1;
-          }
-        }
-      }).serialize(dataSet);
-
-      expect(json.meta.count).equal(1);
       done(null, json);
     });
   });


### PR DESCRIPTION
noticed the [second serialize dataMeta test](https://github.com/SeyZ/jsonapi-serializer/blob/master/test/serializer.js#L258) was the same as [this one](https://github.com/SeyZ/jsonapi-serializer/blob/master/test/serializer.js#L198)

just updated to tests and clarified the readme a bit :)

btw, we just definitely love and started to use the `meta` and `dataMeta` options right away, thank you!