### PR TITLE
don’t serialize id if it isn’t defined

### DIFF
--- a/lib/serializer-utils.js
+++ b/lib/serializer-utils.js
@@ -252,9 +252,15 @@ module.exports = function (collectionName, record, payload, opts) {
 
     // Top-level data.
     var data = {
-      type: getType(collectionName, record),
-      id: String(record[getId()])
+      type: getType(collectionName, record)
     };
+
+    var id = record[getId()];
+
+    // only include id if it's defined on the record
+    if (typeof id !== 'undefined') {
+        data.id = String(id);
+    }
 
     // Data links.
     if (opts.dataLinks) {

--- a/test/serializer.js
+++ b/test/serializer.js
@@ -28,6 +28,20 @@ describe('Options', function () {
       expect(json.data[0].id).equal('54735750e16638ba1eee59cb');
       done(null, json);
     });
+
+    it('should not serialize id if it isn\'t defined', function (done) {
+      var dataSet = [{
+        firstName: 'Sandro',
+        lastName: 'Munda',
+      }];
+
+      var json = new JSONAPISerializer('users', {
+        attributes: ['firstName', 'lastName']
+      }).serialize(dataSet);
+
+      expect(json.data[0]).to.not.have.property('id');
+      done(null, json);
+    });
   });
 
   describe('pluralizeType', function () {


### PR DESCRIPTION
Currently, if you serialize a payload where `id` isn't defined, the resulting JSON API payload will contain `"id": "undefined"`. 

According to the spec, when creating a resource, `id` is not required (`type` is). Reference: http://jsonapi.org/format/#crud