### PR TITLE
do not serialize nested objects when exempted

### DIFF
--- a/lib/serializer-utils.js
+++ b/lib/serializer-utils.js
@@ -15,6 +15,9 @@ module.exports = function (collectionName, record, payload, opts) {
   function isComplexType(obj) {
     return Array.isArray(obj) || isPlainObject(obj);
   }
+  function ignoreNestedArray() {
+    return opts && opts.ignoreNestedArray;
+  }
 
   function keyForAttribute(attribute) {
     if (isPlainObject(attribute)) {
@@ -151,7 +154,7 @@ module.exports = function (collectionName, record, payload, opts) {
       }
     } else {
       if (Array.isArray(current[attribute])) {
-        if (current[attribute].length && isPlainObject(current[attribute][0])) {
+        if (current[attribute].length && isPlainObject(current[attribute][0]) && !ignoreNestedArray()) {
           data = current[attribute].map(function (item) {
             return that.serializeNested(item, current, attribute, opts);
           });

--- a/test/serializer.js
+++ b/test/serializer.js
@@ -387,10 +387,13 @@ describe('Options', function () {
   });
 
   describe('keyForAttribute case strings', function () {
-    var dataSet = {
-      id: '1',
-      firstName: 'Sandro',
-    };
+    var dataSet;
+    beforeEach(function() {
+      dataSet = {
+        id: '1',
+        firstName: 'Sandro',
+      };
+    });
 
     it('should default the key case to dash-case', function (done) {
       var jsonNoCase = new JSONAPISerializer('user', dataSet, {
@@ -406,6 +409,21 @@ describe('Options', function () {
       expect(jsonInvalidCase.data.attributes['first-name']).equal('Sandro');
 
       done(null, jsonNoCase);
+    });
+
+    it('should not mutate nested objects to default case configured otherwise', function (done) {
+      dataSet.countries = [ { short_name: 'Brazil' }, { short_name: 'USA' } ];
+      var json = new JSONAPISerializer('user', {
+        ignoreNestedArray: true,
+        attributes: ['firstName', 'countries']
+      }).serialize(dataSet);
+
+
+      expect(json.data.attributes['first-name']).equal('Sandro');
+      var keys = json.data.attributes.countries.map(function(obj) { return Object.keys(obj).pop(); });
+      expect(keys[0]).to.equal('short_name');
+      expect(keys[1]).to.equal('short_name');
+      done(null, json);
     });
 
     it('should update the key case to dash-case', function (done) {


### PR DESCRIPTION
Fixes #71.
I chose to use a configuration option because this behaviour seemed intentional. If it is, I can add documentation. If not, I can make this the default.
I was not sure about accessing the primary `opts` from within `serializeNested`'s scope, so I opted for the function returning the opt value. I'm open to a clearer way.