### PR TITLE
Fix serialization of id property

### DIFF
--- a/lib/serializer-utils.js
+++ b/lib/serializer-utils.js
@@ -12,7 +12,7 @@ var _pick = require('lodash/pick');
 var _pickBy = require('lodash/pickBy');
 var _keys = require('lodash/keys');
 var _each = require('lodash/each');
-var _isUndefined = require('lodash/isUndefined');
+var _isNil = require('lodash/isNil');
 var Inflector = require('./inflector');
 
 module.exports = function (collectionName, record, payload, opts) {
@@ -265,7 +265,7 @@ module.exports = function (collectionName, record, payload, opts) {
 
     // Top-level data.
     var data = { type: getType(collectionName, record) };
-    if (record[getId()]) { data.id = record[getId()]; }
+    if (!_isNil(record[getId()])) { data.id = String(record[getId()]); }
 
     // Data links.
     if (opts.dataLinks) {

--- a/test/serializer.js
+++ b/test/serializer.js
@@ -57,6 +57,36 @@ describe('Options', function () {
       expect(json.data).to.not.have.keys('id');
       done(null, json);
     });
+
+    it('should be serialized as string when it\'s integer', function (done) {
+      var dataSet = {
+        id: 1,
+        firstName: 'Sandro',
+        lastName: 'Munda'
+      };
+
+      var json = new JSONAPISerializer('user', {
+        attributes: ['firstName', 'lastName'],
+      }).serialize(dataSet);
+
+      expect(json.data.id).to.be.equal('1');
+      done(null, json);
+    });
+
+    it('should be serialized when it\'s integer with zero value', function (done) {
+      var dataSet = {
+        id: 0,
+        firstName: 'Sandro',
+        lastName: 'Munda'
+      };
+
+      var json = new JSONAPISerializer('user', {
+        attributes: ['firstName', 'lastName'],
+      }).serialize(dataSet);
+
+      expect(json.data.id).to.be.equal('0');
+      done(null, json);
+    });
   });
 
   describe('pluralizeType', function () {


### PR DESCRIPTION
Latest version (3.5.6 on npm) introduced change in output when input id is integer:
- id property is not converted to string type any more, but in 3.5.5 it was converted. JSON API specification requires that id is string: http://jsonapi.org/format/#document-resource-object-identification
- if input id property is equal to 0, it is missing in output

Example:

```javascript
var data = [
  { id: 0, firstName: 'Sandro', lastName: 'Munda' },
  { id: 1, firstName: 'John', lastName: 'Doe' }
];

var JSONAPISerializer = require('jsonapi-serializer').Serializer;

var UserSerializer = new JSONAPISerializer('users', {
  attributes: ['firstName', 'lastName']
});

var users = UserSerializer.serialize(data);
```

Current output:

```javascript
{
  "data": [
    {
      "type": "users",
      "id": 1,
      "attributes": {
        "first-name": "John",
        "last-name": "Doe"
      }
    }
}
```

Output with this PR:

```javascript
{
  "data": [
    {
      "type": "users",
      "id": "0",
      "attributes": {
        "first-name": "Sandro",
        "last-name": "Munda"
      }
    }, {
      "type": "users",
      "id": "1",
      "attributes": {
        "first-name": "John",
        "last-name": "Doe"
      }
    }
}
```

 