### PR TITLE
Clean mangoose models in tests

### DIFF
--- a/test/serializer.js
+++ b/test/serializer.js
@@ -2291,8 +2291,15 @@ describe('JSON API Serializer', function () {
   });
 
   describe('Database model objects', function () {
+    var mongoose = require('mongoose');
+
+    afterEach(function () {
+      if (mongoose.models['User']) {
+        delete mongoose.models['User']
+      }
+    })
+
     it('properly pass on requests for attributes', function () {
-      var mongoose = require('mongoose');
       var userSchema = new mongoose.Schema({ firstName: String, lastName: String });
       var User = mongoose.model('User', userSchema);
       var user = new User({ firstName: 'Lawrence', lastName: 'Bennett' });


### PR DESCRIPTION
When mocha used in watch mode:

```bash
npm test -- --watch
```

the test was failing on the second pass with:

```
  105 passing (98ms)
  1 failing

  1) JSON API Serializer Database model objects properly pass on requests for attributes:
     OverwriteModelError: Cannot overwrite `User` model once compiled.
      at OverwriteModelError (node_modules/mongoose/lib/error/overwriteModel.js:18:11)
      at Mongoose.model (node_modules/mongoose/lib/index.js:405:13)
      at Context.<anonymous> (test/serializer.js:2298:27)
```

I'm not a mongo expert, so I'm not sure if the cleanup is done according to best practices so let me know if I could improve it.