### PR TITLE
Fix bug that returned null for polymorphic relationships that reference the same record

### DIFF
--- a/lib/deserializer-utils.js
+++ b/lib/deserializer-utils.js
@@ -4,13 +4,10 @@ var isFunction = require('lodash/isFunction');
 var _find = require('lodash/find');
 var _extend = require('lodash/extend');
 var _transform = require('lodash/transform');
-var _merge = require('lodash/merge');
-var _get = require('lodash/get');
-var _set = require('lodash/set');
 var Inflector = require('./inflector');
 
 module.exports = function (jsonapi, data, opts) {
-  var alreadyIncluded = {};
+  var alreadyIncluded = [];
 
   function isComplexType(obj) {
     return Array.isArray(obj) || isPlainObject(obj);
@@ -27,34 +24,30 @@ module.exports = function (jsonapi, data, opts) {
     }
   }
 
-  function findIncluded(relationshipData, relationshipName, from) {
+  function findIncluded(relationshipData, ancestry) {
     return new Promise(function (resolve) {
-      if (!jsonapi.included || !relationshipData) { return resolve(null); }
+      if (!jsonapi.included || !relationshipData) { resolve(null); }
 
       var included = _find(jsonapi.included, {
         id: relationshipData.id,
         type: relationshipData.type
       });
 
-      var path = [
-        from.type,
-        from.id,
-        relationshipName,
-        relationshipData.type,
-        relationshipData.id,
-      ]
-
-      // Check if the include is already processed (prevent circular
-      // references).
-      if (_get(alreadyIncluded, path, false)) {
-        return resolve(null);
-      } else {
-        _merge(alreadyIncluded, _set({}, path, true));
-      }
-
       if (included) {
+        // To prevent circular references, check if the record type
+        // has already been processed in this thread
+        if (ancestry.indexOf(included.type) > -1) {
+          return Promise
+            .all([extractAttributes(included)])
+            .then(function (results) {
+              var attributes = results[0];
+              var relationships = results[1];
+              resolve(_extend(attributes, relationships));
+            });
+        }
+
         return Promise
-          .all([extractAttributes(included), extractRelationships(included)])
+          .all([extractAttributes(included), extractRelationships(included, `${ancestry}:${included.type}${included.id}`)])
           .then(function (results) {
             var attributes = results[0];
             var relationships = results[1];
@@ -104,7 +97,7 @@ module.exports = function (jsonapi, data, opts) {
     return dest;
   }
 
-  function extractRelationships(from) {
+  function extractRelationships(from, ancestry) {
     if (!from.relationships) { return; }
 
     var dest = {};
@@ -118,15 +111,15 @@ module.exports = function (jsonapi, data, opts) {
         } else if (Array.isArray(relationship.data)) {
           return Promise
             .all(relationship.data.map(function (relationshipData) {
-              return extractIncludes(relationshipData, key, from);
+              return extractIncludes(relationshipData, ancestry);
             }))
             .then(function (includes) {
               if (includes) { dest[keyForAttribute(key)] = includes; }
             });
         } else {
-          return extractIncludes(relationship.data, key, from)
-            .then(function (include) {
-              if (include) { dest[keyForAttribute(key)] = include; }
+          return extractIncludes(relationship.data, ancestry)
+            .then(function (includes) {
+              if (includes) { dest[keyForAttribute(key)] = includes; }
             });
         }
       }))
@@ -135,8 +128,8 @@ module.exports = function (jsonapi, data, opts) {
       });
   }
 
-  function extractIncludes(relationshipData, relationshipName, from) {
-    return findIncluded(relationshipData, relationshipName, from)
+  function extractIncludes(relationshipData, ancestry) {
+    return findIncluded(relationshipData, ancestry)
       .then(function (included) {
         var valueForRelationship = getValueForRelationship(relationshipData,
           included);
@@ -153,7 +146,7 @@ module.exports = function (jsonapi, data, opts) {
 
   this.perform = function () {
     return Promise
-      .all([extractAttributes(data), extractRelationships(data)])
+      .all([extractAttributes(data), extractRelationships(data, `${data.type}${data.id}`)])
       .then(function (results) {
         var attributes = results[0];
         var relationships = results[1];
@@ -163,7 +156,6 @@ module.exports = function (jsonapi, data, opts) {
         if (jsonapi.links) {
           record.links = jsonapi.links;
         }
-
 
         // If option is present, transform record
         if (opts && opts.transform) {

--- a/lib/deserializer-utils.js
+++ b/lib/deserializer-utils.js
@@ -47,7 +47,7 @@ module.exports = function (jsonapi, data, opts) {
         }
 
         return Promise
-          .all([extractAttributes(included), extractRelationships(included, `${ancestry}:${included.type}${included.id}`)])
+          .all([extractAttributes(included), extractRelationships(included, ancestry + ':' + included.type + included.id)])
           .then(function (results) {
             var attributes = results[0];
             var relationships = results[1];
@@ -146,7 +146,7 @@ module.exports = function (jsonapi, data, opts) {
 
   this.perform = function () {
     return Promise
-      .all([extractAttributes(data), extractRelationships(data, `${data.type}${data.id}`)])
+      .all([extractAttributes(data), extractRelationships(data, data.type + data.id)])
       .then(function (results) {
         var attributes = results[0];
         var relationships = results[1];

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "author": "Sandro Munda <sandro@munda.me>",
   "license": "MIT",
   "repository": "SeyZ/jsonapi-serializer",
-  "engines" : { "node" : ">=0.12" },
+  "engines": {
+    "node": ">=0.12"
+  },
   "dependencies": {
     "inflected": "^1.1.6",
     "lodash": "^4.16.3"


### PR DESCRIPTION
Currently, if a model (e.g. images) has a polymorphic one-to-many relationship with another model (e.g. tags) and multiple image records reference the same tag record, every instance after the first will be resolved as null.

I replaced the current logic to calculate a circular reference error with a new logic that tracks each relationship branch recursively. This solves the problem I stated above and still prevents circular reference errors.

All tests are passing. I added two new tests to reference my polymorphic, one-to-many problem as well as a more complex circular reference test.