### PR TITLE
Apply deserializer option to links

### DIFF
--- a/lib/deserializer-utils.js
+++ b/lib/deserializer-utils.js
@@ -151,19 +151,31 @@ module.exports = function (jsonapi, data, opts) {
       });
   }
 
+  function extractLinks(from) {
+    return keyForAttribute(from.links);
+  }
+
   this.perform = function () {
+    var dataToBeExtracted = [
+      extractAttributes(data),
+      extractRelationships(data)
+    ];
+
+    if (jsonapi.links) {
+      dataToBeExtracted.push(extractLinks(jsonapi));
+    }
+
     return Promise
-      .all([extractAttributes(data), extractRelationships(data)])
+      .all(dataToBeExtracted)
       .then(function (results) {
         var attributes = results[0];
         var relationships = results[1];
         var record = _extend(attributes, relationships);
 
         // Links
-        if (jsonapi.links) {
-          record.links = jsonapi.links;
+        if (results[2]) {
+          record.links = results[2];
         }
-
 
         // If option is present, transform record
         if (opts && opts.transform) {

--- a/test/deserializer.js
+++ b/test/deserializer.js
@@ -1291,16 +1291,20 @@ describe('JSON API Deserializer', function () {
         },
         links: {
           self: '/articles/1/relationships/tags',
-          related: '/articles/1/tags'
+          related: '/articles/1/tags',
+          'extra-info': '/articles/1/extra/info'
         }
       };
 
-      new JSONAPIDeserializer()
+      new JSONAPIDeserializer({
+        keyForAttribute: 'camelCase'
+      })
       .deserialize(dataSet, function (err, json) {
-        expect(json).to.have.key('first-name', 'last-name', 'links');
+        expect(json).to.have.key('firstName', 'lastName', 'links');
         expect(json.links).to.be.eql({
           self: '/articles/1/relationships/tags',
-          related: '/articles/1/tags'
+          related: '/articles/1/tags',
+          extraInfo: '/articles/1/extra/info'
         });
 
         done(null, json);


### PR DESCRIPTION
Right now deserializer option (keyForAttribute) does not get applied to links.