### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   },
   "devDependencies": {
     "chai": "^2.3.0",
-    "grunt": "^0.4.5",
-    "grunt-browserify": "^4.0.0",
-    "mocha": "^2.2.5",
+    "grunt": "^1.0.2",
+    "grunt-browserify": "^5.3.0",
+    "mocha": "^5.2.0",
     "mongoose": "^4.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "chai": "^2.3.0",
     "grunt": "^1.0.2",
     "grunt-browserify": "^5.3.0",
-    "mocha": "^4.1.0",
+    "mocha": "^3.5.3",
     "mongoose": "^4.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "chai": "^2.3.0",
     "grunt": "^1.0.2",
     "grunt-browserify": "^5.3.0",
-    "mocha": "^5.2.0",
+    "mocha": "^4.1.0",
     "mongoose": "^4.3.4"
   }
 }


### PR DESCRIPTION
These packages are really outdated can be updated without breaking the tests:
- `grunt`
- `grunt-browserify`
- `mocha`

Before:
```
λ ~/jsonapi-serializer/ master yarn
yarn install v1.7.0
info No lockfile found.
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
warning grunt > coffee-script@1.3.3: CoffeeScript on NPM has moved to "coffeescript" (no hyphen)
warning grunt > minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
warning grunt > glob > minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
warning grunt > findup-sync > glob > minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
warning grunt > glob > graceful-fs@1.2.3: please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js
warning grunt-browserify > browserify > glob > minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
warning mocha > to-iso-string@0.0.2: to-iso-string has been deprecated, use @segment/to-iso-string instead.
warning mocha > jade@0.26.3: Jade has been renamed to pug, please install the latest version of pug instead of jade
[3/5] 🚚  Fetching packages...
[4/5] 🔗  Linking dependencies...
[5/5] 📃  Building fresh packages...
```

After:
```
λ ~/jsonapi-serializer/ master* yarn
yarn install v1.7.0
info No lockfile found.
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
[3/5] 🚚  Fetching packages...
[4/5] 🔗  Linking dependencies...
[5/5] 📃  Building fresh packages...
```

@SeyZ 