### PR TITLE
Avoid relationships links to be broken

### DIFF
--- a/lib/serializer-utils.js
+++ b/lib/serializer-utils.js
@@ -154,8 +154,10 @@ module.exports = function (collectionName, record, payload, opts) {
       }
 
       if (opts.relationshipLinks) {
-        dest.relationships[keyForAttribute(attribute)].links =
-          getLinks(current[attribute], opts.relationshipLinks, dest);
+        const links = getLinks(current[attribute], opts.relationshipLinks, dest);
+        if (links.related) {
+          dest.relationships[keyForAttribute(attribute)].links = links;
+        }
       }
 
       if (opts.relationshipMeta) {

--- a/test/serializer.js
+++ b/test/serializer.js
@@ -2559,5 +2559,32 @@ describe('JSON API Serializer', function () {
         relationships: { publisher: { data: null, links: { related: 'bar' } } }
       }]);
     });
+
+    it('should not be set when the relationshipLinks return null', function () {
+      var dataSet = {
+        id: '1',
+        name: 'Sandro',
+        books: [{
+          id: '1',
+        }, {
+          id: '2',
+        }]
+      };
+
+      var json = new JSONAPISerializer('users', {
+        attributes: ['name'],
+        books: {
+          ref: 'id',
+          included: false,
+          relationshipLinks: {
+            related: function () {
+              return null;
+            }
+          },
+        }
+      }).serialize(dataSet);
+
+      expect(json.data.relationships).to.be.undefined;
+    });
   });
 });

--- a/test/serializer.js
+++ b/test/serializer.js
@@ -2562,18 +2562,15 @@ describe('JSON API Serializer', function () {
 
     it('should not be set when the relationshipLinks return null', function () {
       var dataSet = {
-        id: '1',
-        name: 'Sandro',
-        books: [{
-          id: '1',
-        }, {
-          id: '2',
-        }]
+        id: '54735750e16638ba1eee59cb',
+        firstName: 'Sandro',
+        lastName: 'Munda',
+        address: null,
       };
 
       var json = new JSONAPISerializer('users', {
-        attributes: ['name'],
-        books: {
+        attributes: ['firstName', 'lastName', 'address'],
+        address: {
           ref: 'id',
           included: false,
           relationshipLinks: {
@@ -2584,7 +2581,7 @@ describe('JSON API Serializer', function () {
         }
       }).serialize(dataSet);
 
-      expect(json.data.relationships).to.be.undefined;
+      expect(json.data.relationships.address).eql({ data: null });
     });
   });
 });


### PR DESCRIPTION
When relation ship links is null or undefined the object should not be set or the jsonapi is broken