### PR TITLE
Extract links & meta for collection

### DIFF
--- a/lib/deserializer-utils.js
+++ b/lib/deserializer-utils.js
@@ -163,6 +163,9 @@ module.exports = function (jsonapi, data, opts) {
       if (jsonapi.links) {
         result.links = keyForAttribute(jsonapi.links);
       }
+      if (jsonapi.meta) {
+        result.meta = keyForAttribute(jsonapi.meta);
+      }
       return result;
     });
   }

--- a/lib/deserializer-utils.js
+++ b/lib/deserializer-utils.js
@@ -10,7 +10,7 @@ var _set = require('lodash/set');
 var Inflector = require('./inflector');
 
 module.exports = function (jsonapi, data, opts) {
-  var alreadyIncluded = {};
+  var alreadyIncluded;
 
   function isComplexType(obj) {
     return Array.isArray(obj) || isPlainObject(obj);
@@ -155,7 +155,21 @@ module.exports = function (jsonapi, data, opts) {
       });
   }
 
-  this.perform = function () {
+  function deserializeCollection (array) {
+    var collection = array.map(function (data) {
+      return deserializeRecord(data)
+    })
+    return Promise.all(collection).then(function (result) {
+      if (jsonapi.links) {
+        result.links = keyForAttribute(jsonapi.links);
+      }
+      return result;
+    });
+  }
+
+  function deserializeRecord (data) {
+    alreadyIncluded = {};
+
     var thingsToBeExtracted = [
       extractAttributes(data),
       extractRelationships(data)
@@ -187,5 +201,12 @@ module.exports = function (jsonapi, data, opts) {
 
         return record;
       });
+  }
+
+  this.perform = function () {
+    if (Array.isArray(jsonapi.data)) {
+      return deserializeCollection(jsonapi.data);
+    }
+    return deserializeRecord(jsonapi.data);
   };
 };

--- a/lib/deserializer-utils.js
+++ b/lib/deserializer-utils.js
@@ -135,6 +135,10 @@ module.exports = function (jsonapi, data, opts) {
       });
   }
 
+  function extractLinks(from) {
+    return keyForAttribute(from.links);
+  }
+
   function extractIncludes(relationshipData, relationshipName, from) {
     return findIncluded(relationshipData, relationshipName, from)
       .then(function (included) {
@@ -152,18 +156,29 @@ module.exports = function (jsonapi, data, opts) {
   }
 
   this.perform = function () {
+    var thingsToBeExtracted = [
+      extractAttributes(data),
+      extractRelationships(data)
+    ];
+
+    if (isPlainObject(data.links)) {
+      thingsToBeExtracted.push(extractLinks(data));
+    }
+
     return Promise
-      .all([extractAttributes(data), extractRelationships(data)])
+      .all(thingsToBeExtracted)
       .then(function (results) {
         var attributes = results[0];
         var relationships = results[1];
+        if (results[2]) {
+          var links = results[2];
+        }
         var record = _extend(attributes, relationships);
 
         // Links
-        if (jsonapi.links) {
-          record.links = jsonapi.links;
+        if (links) {
+          record.links = links;
         }
-
 
         // If option is present, transform record
         if (opts && opts.transform) {

--- a/lib/deserializer.js
+++ b/lib/deserializer.js
@@ -6,36 +6,13 @@ module.exports = function (opts) {
   if (!opts) { opts = {}; }
 
   this.deserialize = function (jsonapi, callback) {
-    function collection() {
-      return Promise
-        .all(jsonapi.data.map(function (d) {
-          return new DeserializerUtils(jsonapi, d, opts).perform();
-        }))
-        .then(function (result) {
-          if (isFunction(callback)) {
-            callback(null, result);
-          }
-
-          return result
-        });
-    }
-
-    function resource() {
-      return new DeserializerUtils(jsonapi, jsonapi.data, opts)
-        .perform()
-        .then(function (result) {
-          if (isFunction(callback)) {
-            callback(null, result);
-          }
-
-          return result
-        });
-    }
-
-    if (Array.isArray(jsonapi.data)) {
-      return collection();
-    } else {
-      return resource();
-    }
+    return new DeserializerUtils(jsonapi, jsonapi.data, opts)
+      .perform()
+      .then(function (result) {
+        if (isFunction(callback)) {
+          callback(null, result);
+        }
+        return result;
+      })
   };
 };

--- a/test/deserializer.js
+++ b/test/deserializer.js
@@ -1341,6 +1341,59 @@ describe('JSON API Deserializer', function () {
         done(null, json);
       });
     });
+
+    it('should be included for the collection', function (done) {
+      var dataSet = {
+        data: [{
+          type: 'users',
+          attributes: { 'first-name': 'Sandro', 'last-name': 'Munda' },
+          links: {
+            self: '/users/Tomas'
+          }
+        }, {
+          type: 'users',
+          attributes: { 'first-name': 'Lawrence', 'last-name': 'Bennett' },
+          links: {
+            self: '/users/Marcus'
+          }
+        }],
+        links: {
+          all: '/users',
+          winners: {
+            href: '/winners',
+            meta: {
+              'top-score': 192
+            }
+          }
+        }
+      };
+
+      new JSONAPIDeserializer({
+        keyForAttribute: 'camelCase'
+      })
+      .deserialize(dataSet, function (err, json) {
+        expect(json[0]).to.have.key('firstName', 'lastName', 'links');
+        expect(json[0].links).to.be.eql({
+          self: '/users/Tomas'
+        });
+
+        expect(json[1]).to.have.key('firstName', 'lastName', 'links');
+        expect(json[1].links).to.be.eql({
+          self: '/users/Marcus'
+        });
+
+        expect(json.links).to.eql({
+          all: '/users',
+          winners: {
+            href: '/winners',
+            meta: {
+              topScore: 192
+            }
+          }
+        });
+        done(null, json);
+      });
+    });
   });
 
   describe('id', function () {

--- a/test/deserializer.js
+++ b/test/deserializer.js
@@ -1229,7 +1229,7 @@ describe('JSON API Deserializer', function () {
   });
 
   describe('meta', function () {
-    it('should be included', function (done) {
+    it('should be included for a resource', function (done) {
       var dataSet = {
         data: {
           type: 'users',
@@ -1254,7 +1254,37 @@ describe('JSON API Deserializer', function () {
       });
     });
 
-     it('should be in camelCase', function (done) {
+    it('should be included for a collection', function (done) {
+      var dataSet = {
+        data: [{
+          type: 'users',
+          attributes: { 'first-name': 'Sandro', 'last-name': 'Munda' }
+        }, {
+          type: 'users',
+          attributes: { 'first-name': 'Lawrence', 'last-name': 'Bennett' }
+        }],
+        meta: {
+          count: 2,
+          'top-score': 192
+        }
+      };
+
+      new JSONAPIDeserializer({
+        keyForAttribute: 'camelCase'
+      })
+      .deserialize(dataSet, function (err, json) {
+        expect(json[0]).to.have.key('firstName', 'lastName');
+        expect(json[1]).to.have.key('firstName', 'lastName');
+        expect(json.meta).to.eql({
+          count: 2,
+          topScore: 192
+        });
+
+        done(null, json);
+      });
+    });
+
+    it('should be in camelCase', function (done) {
        var dataSet = {
          data: {
            type: 'users',

--- a/test/deserializer.js
+++ b/test/deserializer.js
@@ -1283,15 +1283,15 @@ describe('JSON API Deserializer', function () {
   });
 
   describe('links', function () {
-    it('should be included', function (done) {
+    it('should be included for a resource', function (done) {
       var dataSet = {
         data: {
           type: 'users',
           attributes: { 'first-name': 'Sandro', 'last-name': 'Munda' },
-        },
-        links: {
-          self: '/articles/1/relationships/tags',
-          related: '/articles/1/tags'
+          links: {
+            self: '/articles/1/relationships/tags',
+            related: '/articles/1/tags'
+          }
         }
       };
 
@@ -1301,6 +1301,41 @@ describe('JSON API Deserializer', function () {
         expect(json.links).to.be.eql({
           self: '/articles/1/relationships/tags',
           related: '/articles/1/tags'
+        });
+
+        done(null, json);
+      });
+    });
+
+    it('should be included for each record in a collection', function (done) {
+      var dataSet = {
+        data: [{
+          type: 'users',
+          attributes: { 'first-name': 'Sandro', 'last-name': 'Munda' },
+          links: {
+            self: '/users/Tomas'
+          }
+        }, {
+          type: 'users',
+          attributes: { 'first-name': 'Lawrence', 'last-name': 'Bennett' },
+          links: {
+            'next-user': '/users/Marcus'
+          }
+        }]
+      };
+
+      new JSONAPIDeserializer({
+        keyForAttribute: 'camelCase'
+      })
+      .deserialize(dataSet, function (err, json) {
+        expect(json[0]).to.have.key('firstName', 'lastName', 'links');
+        expect(json[0].links).to.be.eql({
+          self: '/users/Tomas'
+        });
+
+        expect(json[1]).to.have.key('firstName', 'lastName', 'links');
+        expect(json[1].links).to.be.eql({
+          nextUser: '/users/Marcus'
         });
 
         done(null, json);


### PR DESCRIPTION
`links` & `meta` can exist at two levels according to the [jsonapi spec](https://jsonapi.org/format/)

1. For each record
```
{
  data: [{
    type: 'users',
    id: '54735750e16638ba1eee59cb',
    attributes: { 'first-name': 'Sandro', 'last-name': 'Munda' },
    links: {
      self: '/users/54735750e16638ba1eee59cb'
    },
    meta: {
      score: 40
    }
  }, {
    type: 'users',
    id: '5490143e69e49d0c8f9fc6bc',
    attributes: { 'first-name': 'Lawrence', 'last-name': 'Bennett' },
    links: {
      self: '/users/5490143e69e49d0c8f9fc6bc'
    },
    meta: {
      score: 20
    }
  }]
}
```

2. For the collection as a whole. Not each record in the collection can have them as well.
```
{
  data: [{
    type: 'users',
    id: '54735750e16638ba1eee59cb',
    attributes: { 'first-name': 'Sandro', 'last-name': 'Munda' },
    links: {
      self: '/users/54735750e16638ba1eee59cb'
    },
    meta: {
      score: 40
    }
  }, {
    type: 'users',
    id: '5490143e69e49d0c8f9fc6bc',
    attributes: { 'first-name': 'Lawrence', 'last-name': 'Bennett' },
    links: {
      self: '/users/5490143e69e49d0c8f9fc6bc'
    },
    meta: {
      score: 20
    }
  }],
  links: {
    all: '/users'
  },
  meta: {
    'top-score': 40,
    count: 2
  }
}
```

Currently these two cases are not handled separately by the deserializer.
This PR aims to fix how metadata is extracted for both resources and collections.