### PR TITLE
introduce relationshipLinksIfMissing

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Calling the `serialize` method on the returned object will serialize your `data`
     - **ignoreRelationshipData**: Do not include the `data` key inside the relationship. Default: false.
     - **keyForAttribute**: A function or string to customize attributes. Functions are passed the attribute as a single argument and expect a string to be returned. Strings are aliases for inbuilt functions for common case conversions. Options include: `dash-case` (default), `lisp-case`, `spinal-case`, `kebab-case`, `underscore_case`, `snake_case`, `camelCase`, `CamelCase`.
     - **nullIfMissing**: Set the attribute to null if missing from your data input. Default: false.
+    - **relationshipLinksIfMissing**: Serialize relationship links if the attribute is missing from your data input. Default: false.
     - **pluralizeType**: A boolean to indicate if the type must be pluralized or not. Default: true.
     - **typeForAttribute**: A function that maps the attribute (passed as an argument) to the type you want to override. If it returns `undefined`, ignores the flag for that attribute. Option *pluralizeType* ignored if set.
     - **meta**: An object to include non-standard meta-information. Values can be a plain value or a *function*

--- a/lib/serializer-utils.js
+++ b/lib/serializer-utils.js
@@ -153,7 +153,7 @@ module.exports = function (collectionName, record, payload, opts) {
       }
 
       dest.relationships[keyForAttribute(attribute)] = {};
-      if (!opts.ignoreRelationshipData) {
+      if (!opts.ignoreRelationshipData && attribute in current) {
         dest.relationships[keyForAttribute(attribute)].data = data;
       }
 
@@ -217,7 +217,7 @@ module.exports = function (collectionName, record, payload, opts) {
     if (includedAttrs) { included.attributes = pick(dest, includedAttrs); }
 
     relationships.forEach(function (relationship) {
-      if (dest && (isComplexType(dest[relationship]) || dest[relationship] === null)) {
+      if (dest && (isComplexType(dest[relationship]) || dest[relationship] === null || dest[relationship] === undefined)) {
         that.serialize(included, dest, relationship, opts[relationship]);
       }
     });
@@ -297,7 +297,7 @@ module.exports = function (collectionName, record, payload, opts) {
         record[attribute] = null;
       }
 
-      if (splittedAttributes[0] in record) {
+      if (splittedAttributes[0] in record || (opts[attribute] && opts[attribute].relationshipLinksIfMissing)) {
         if (!data.attributes) { data.attributes = {}; }
 
         var attributeMap = attribute;

--- a/test/serializer.js
+++ b/test/serializer.js
@@ -2622,5 +2622,30 @@ describe('JSON API Serializer', function () {
 
       expect(json.data.relationships.address).eql({ data: null });
     });
+
+    it('should serialize relationshipLinks when missing and nullIfMissing: false', function () {
+      var dataSet = {
+        id: '54735750e16638ba1eee59cb',
+        firstName: 'Sandro',
+        lastName: 'Munda',
+      };
+
+      var json = new JSONAPISerializer('users', {
+        attributes: ['firstName', 'lastName', 'address'],
+        address: {
+          ref: 'id',
+          ignoreRelationshipData: false,
+          nullIfMissing: false,
+          relationshipLinksIfMissing: true,
+          relationshipLinks: {
+            related: '/foo/bar'
+          },
+        }
+      }).serialize(dataSet);
+
+      expect(json.data.relationships).eql({
+        address: { links: { related: '/foo/bar' } }
+      });
+    });
   });
 });


### PR DESCRIPTION
This is an alternative for #197. While #197 is a failing test for the *default behaviour* this introduces a new option `relationshipLinksIfMissing` and does not change the default behaviour.

Also this is a full implementation (not only a failing test).