### PR TITLE
Don't set included.relationships if empty

### DIFF
--- a/lib/serializer-utils.js
+++ b/lib/serializer-utils.js
@@ -12,6 +12,7 @@ var _pickBy = require('lodash/pickBy');
 var _keys = require('lodash/keys');
 var _each = require('lodash/each');
 var _isNil = require('lodash/isNil');
+var _isEmpty = require('lodash/isEmpty');
 var Inflector = require('./inflector');
 
 module.exports = function (collectionName, record, payload, opts) {
@@ -123,8 +124,12 @@ module.exports = function (collectionName, record, payload, opts) {
     var included = isCompoundDocumentIncluded(dest, include);
     if (included) {
       // Merge relationships
-      included.relationships = _merge(included.relationships,
+      var merged = _merge(included.relationships,
         _pickBy(include.relationships, _identity));
+
+      if(!_isEmpty(merged)){
+        included.relationships = merged;
+      }
 
       // Merge attributes
       included.attributes = _merge(included.attributes,

--- a/test/serializer.js
+++ b/test/serializer.js
@@ -990,6 +990,64 @@ describe('JSON API Serializer', function () {
 
       done(null, json);
     });
+    it('should not add empty `relationships` in `included`', function (done) {
+      var dataSet = [{
+        id: '54735750e16638ba1eee59cb',
+        firstName: 'Sandro',
+        lastName: 'Munda',
+        address: {
+          id: '54735722e16620ba1eee36af',
+          addressLine1: '406 Madison Court',
+          zipCode: '49426',
+          country: 'USA'
+        },
+      }, {
+        id: '5490143e69e49d0c8f9fc6bc',
+        firstName: 'Jane',
+        lastName: 'Munda',
+        address: {
+          id: '54735722e16620ba1eee36af',
+          addressLine1: '406 Madison Court',
+          zipCode: '49426',
+          country: 'USA'
+        },
+      }];
+
+      var json = new JSONAPISerializer('users', {
+        attributes: ['firstName', 'lastName', 'address'],
+        address: {
+          ref: 'id',
+          included: true,
+          attributes: ['addressLine1', 'addressLine2', 'zipCode', 'country']
+        }
+      }).serialize(dataSet);
+
+      expect(json.included).to.have.length(1);
+
+      expect(json.included[0]).to.have.property('id')
+        .equal('54735722e16620ba1eee36af');
+
+      expect(json.included[0]).to.have.property('type').equal('addresses');
+
+      expect(json.included[0]).to.have.property('attributes').to.be
+        .an('object').eql({
+          'address-line1': '406 Madison Court',
+          'zip-code': '49426',
+          'country': 'USA'
+        });
+
+      expect(json.data[0].relationships).to.have.property('address').that.is
+        .an('object');
+
+      expect(json.data[0].relationships.address.data).eql({
+        id: '54735722e16620ba1eee36af',
+        type: 'addresses'
+      });
+
+      expect(json.included[0]).to.not.have.property('relationships');
+      
+      done(null, json);
+    });
   });
 
   describe('Compound documents', function () {


### PR DESCRIPTION
empty object (`{}`) is added to `included.relationships` when multiple identical references exist in the dataset