### PR TITLE
Replaces deep merge with shallow key sets on alreadyIncluded

### DIFF
--- a/lib/deserializer-utils.js
+++ b/lib/deserializer-utils.js
@@ -4,9 +4,7 @@ var isFunction = require('lodash/isFunction');
 var _find = require('lodash/find');
 var _extend = require('lodash/extend');
 var _transform = require('lodash/transform');
-var _merge = require('lodash/merge');
 var _get = require('lodash/get');
-var _set = require('lodash/set');
 var Inflector = require('./inflector');
 
 module.exports = function (jsonapi, data, opts) {
@@ -42,14 +40,14 @@ module.exports = function (jsonapi, data, opts) {
         relationshipName,
         relationshipData.type,
         relationshipData.id,
-      ]
+      ].join(',')
 
       // Check if the include is already processed (prevent circular
       // references).
-      if (_get(alreadyIncluded, path, false)) {
+      if (path in alreadyIncluded) {
         return resolve(null);
       } else {
-        _merge(alreadyIncluded, _set({}, path, true));
+        alreadyIncluded[path] = true;
       }
 
       if (included) {


### PR DESCRIPTION
I've encountered some performance issues using lodash's `_set` and `_merge` objects. I clocked in over 10 seconds for deserialization of a large, nested JSONAPI object. This isn't a fault of the library, just the nature of deep merges.

I've replaced the deep merge with a top level key set of a stringified path and brought down deserialization time on my case to be negligible.

Feedback is appreciated. Thanks in advance!