### PR TITLE
[BUGFIX] ancestry can be undefined

### DIFF
--- a/browserify/jsonapi-serializer.js
+++ b/browserify/jsonapi-serializer.js
@@ -37,7 +37,7 @@ module.exports = function (jsonapi, data, opts) {
       if (included) {
         // To prevent circular references, check if the record type
         // has already been processed in this thread
-        if (ancestry.indexOf(included.type) > -1) {
+        if (ancestry && ancestry.indexOf(included.type) > -1) {
           return Promise
             .all([extractAttributes(included)])
             .then(function (results) {

--- a/lib/deserializer-utils.js
+++ b/lib/deserializer-utils.js
@@ -36,7 +36,7 @@ module.exports = function (jsonapi, data, opts) {
       if (included) {
         // To prevent circular references, check if the record type
         // has already been processed in this thread
-        if (ancestry.indexOf(included.type) > -1) {
+        if (ancestry && ancestry.indexOf(included.type) > -1) {
           return Promise
             .all([extractAttributes(included)])
             .then(function (results) {


### PR DESCRIPTION
ancestry can be undefined. Faced this issue with some public facing APIs:
<img width="309" alt="Screenshot 2020-01-14 at 12 43 25 AM" src="https://user-images.githubusercontent.com/4788281/72274342-eed93d80-3666-11ea-896a-35949d2ac9d1.png">
