### PR TITLE
Change package name

### DIFF
--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "express",
+  "name": "express-example",
   "version": "0.0.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Differentiate this example package name from the popular `express` package.
This triggers some SAST tools (like twistlock) because the version is `0.0.0`