### PR TITLE
Rename the example package name

### DIFF
--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "express",
+  "name": "express-example",
   "version": "0.0.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Security tools scan the package.json, it thinks the project import `express@0.0.0`, so I rename the example package name.