### PR TITLE
Renders relationship objects even where's no data on included

### DIFF
--- a/lib/deserializer-utils.js
+++ b/lib/deserializer-utils.js
@@ -26,9 +26,9 @@ module.exports = function (jsonapi, data, opts) {
 
   function findIncluded(relationshipData, ancestry) {
     return new Promise(function (resolve) {
-      if (!jsonapi.included || !relationshipData) { resolve(null); }
+      if (!relationshipData) { resolve(null); }
 
-      var included = _find(jsonapi.included, {
+      var included = _find(jsonapi.included || [], {
         id: relationshipData.id,
         type: relationshipData.type
       });
@@ -54,7 +54,7 @@ module.exports = function (jsonapi, data, opts) {
             resolve(_extend(attributes, relationships));
           });
       } else {
-        return resolve(null);
+        return resolve({ id: relationshipData.id });
       }
     });
   }

--- a/test/deserializer.js
+++ b/test/deserializer.js
@@ -392,7 +392,8 @@ describe('JSON API Deserializer', function () {
               id: '54735697e16624ba1eee36bf',
               'address-line1': '361 Shady Lane',
               'zip-code': '23185',
-              country: 'USA'
+              country: 'USA',
+              lock: { id: '2' }
             });
 
             done();
@@ -478,7 +479,7 @@ describe('JSON API Deserializer', function () {
           .deserialize(dataSet, function (err, json) {
             expect(json).to.be.an('object');
 
-            expect(json).to.have.key('id', 'first-name', 'last-name', 
+            expect(json).to.have.key('id', 'first-name', 'last-name',
               'username', 'images');
 
             expect(json.images).to.be.an('array').with.length(2)
@@ -553,7 +554,7 @@ describe('JSON API Deserializer', function () {
               id: '2',
               type: 'stores',
               attributes: {
-                name: 'Fashionable Clothes' 
+                name: 'Fashionable Clothes'
               },
               relationships: {
                 deals: {
@@ -619,7 +620,7 @@ describe('JSON API Deserializer', function () {
               name: 'Twin Pines Mall',
               id: '1',
               stores: [
-                { 
+                {
                   name: 'Tasty Food',
                   id: '1',
                   deals: [
@@ -634,10 +635,10 @@ describe('JSON API Deserializer', function () {
                       id: '2',
                       stores: [
                         { name: 'Tasty Food', id: '1' }
-                      ] 
-                    } 
+                      ]
+                    }
                   ]
-                }, { 
+                }, {
                   name: 'Fashionable Clothes',
                   id: '2',
                   deals: [
@@ -649,10 +650,10 @@ describe('JSON API Deserializer', function () {
                       ]
                     }
                   ]
-                }, { 
+                }, {
                   name: 'Readable Books',
                   id: '3'
-                } 
+                }
               ],
               deals: [
                 {
@@ -696,7 +697,7 @@ describe('JSON API Deserializer', function () {
                     }
                   ]
                 }
-              ] 
+              ]
             });
 
             done(null, json);
@@ -1130,6 +1131,29 @@ describe('JSON API Deserializer', function () {
           done(null, json);
         });
       });
+
+      it('Should include relationship object withonly id', function (done){
+        var dataSet = _.cloneDeep(baseDataSet);
+
+        new JSONAPIDeserializer()
+          .deserialize(dataSet, function (err, json) {
+            expect(json).to.be.an('array').with.length(2);
+            expect(json[0]).to.be.eql({
+              id: '54735750e16638ba1eee59cb',
+              'first-name': 'Sandro',
+              'last-name': 'Munda',
+              'address': { id: '54735722e16620ba1eee36af' }
+            });
+            expect(json[1]).to.be.eql({
+              id: '5490143e69e49d0c8f9fc6bc',
+              'first-name': 'Lawrence',
+              'last-name': 'Bennett',
+              'address': { id: '54735697e16624ba1eee36bf' }
+            });
+
+            done(null, json);
+          });
+      })
     });
 
     describe('With empty relationship', function () {


### PR DESCRIPTION
Issue opened with the description of error: https://github.com/SeyZ/jsonapi-serializer/issues/253

When the deserializer receives a relationship without included data, they just ignore it, but sometimes, for performance uses, we just need the object id, and dont want to include the entire object on response data. This solution add an object with just an in on the output of deserializer.